### PR TITLE
Blink1 clean restart

### DIFF
--- a/hardware/blink/77-blink1.js
+++ b/hardware/blink/77-blink1.js
@@ -58,7 +58,7 @@ function Blink1Node(n) {
         var blink1 = new Blink1.Blink1();
     }
     catch(e) {
-        node.error("No Blink1 found");
+        node.error("No Blink1 found (" + e + ")");
     }
 }
 RED.nodes.registerType("blink1",Blink1Node);


### PR DESCRIPTION
Currently, any sketch involving a blink1 will break after you hit "Deploy" the second time.  This PR uses the recently-added "close" feature in the node-blink1 module to close the HID device on restart, so it can be opened again.
