### PR TITLE
Blink fix

### DIFF
--- a/hardware/blink/77-blink1.js
+++ b/hardware/blink/77-blink1.js
@@ -70,7 +70,6 @@ function Blink1Node(n) {
                 blink1.close();
             }
         });
-//        var blink1 = new Blink1.Blink1();
     }
     catch(e) {
         node.error("No Blink1 found (" + e + ")");


### PR DESCRIPTION
Thanks to @dceejay this now appears to fix the issues where the blink hardware could not be opened on a redeploy, or when used in multiple flows. Closes #11 and #20
