### PR TITLE
Payload format change for emoncms v8.0

### DIFF
--- a/io/emoncms/88-emoncms.js
+++ b/io/emoncms/88-emoncms.js
@@ -80,10 +80,9 @@ function Emoncms(n) {
 
         var topic = this.topic || msg.topic;
         var nodegroup = this.nodegroup || msg.nodegroup;
-        this.url = this.baseurl + '/input/post.json?json={' + topic + ':' + msg.payload+'}&apikey='+this.apikey;
         if(nodegroup != ""){
-            this.url += '&node='+nodegroup;
-        }
+            this.url = this.baseurl + '/input/post.json?node=' + nodegroup + '&csv=' + msg.payload+'&apikey='+this.apikey;
+	     }
         node.log("[emoncms] "+this.url);
         http.get(this.url, function(res) {
             node.log("Http response: " + res.statusCode);


### PR DESCRIPTION
A payload format change is necessary for the node to function with emoncms v8.0 (current version).
The latest version of emoncms introduces a 'key' to identify inputs within each emoncms node group, and is automatically assigned by emoncms, but for this to occur, it is necessary to change the format of the payload.
The changes have also been tested with multiple inputs in the same node, ie inject a comma-separated payload such as 100,98,365 and emoncms will automatically parse the values, and result in 3 inputs within the same emoncms node.
These changes are also backwards-compatible with previous emoncms versions.
