### PR TITLE
Accelerometer notification not taken do to "accelerometer" spelling

### DIFF
--- a/hardware/sensorTag/79-sensorTag.js
+++ b/hardware/sensorTag/79-sensorTag.js
@@ -118,7 +118,7 @@ function enable(node) {
     } else {
        node.stag.unnotifyHumidity(function() {});
     }
-    if (node.accelometer){
+    if (node.accelerometer){
        node.stag.notifyAccelerometer(function() {});
     } else {
        node.stag.unnotifyAccelerometer(function() {});


### PR DESCRIPTION
Hello,

Bad accelerometer spelling => accelerometer checkbox not taken into account.

lahorde
