### PR TITLE
Preliminary support for TI Sensortag 2

### DIFF
--- a/hardware/sensorTag/79-sensorTag.html
+++ b/hardware/sensorTag/79-sensorTag.html
@@ -66,7 +66,7 @@
     </div>
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> Luxometer</label>
-        <input type="checkbox" id="node-input-luxometer" >
+        <input type="checkbox" id="node-input-lux" >
     </div>
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> Keys</label>
@@ -108,7 +108,7 @@
             magnetometer: {value:true},
             accelerometer: {value:true},
             gyroscope: {value:true},
-            luxometer: {value:true},
+            lux: {value:true},
             keys: {value:true}
         },
         inputs:0,                // set the number of inputs - only 0 or 1

--- a/hardware/sensorTag/79-sensorTag.html
+++ b/hardware/sensorTag/79-sensorTag.html
@@ -65,6 +65,10 @@
         <input type="checkbox" id="node-input-gyroscope" >
     </div>
     <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Luxometer</label>
+        <input type="checkbox" id="node-input-luxometer" >
+    </div>
+    <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> Keys</label>
         <input type="checkbox" id="node-input-keys" >
     </div>
@@ -104,6 +108,7 @@
             magnetometer: {value:true},
             accelerometer: {value:true},
             gyroscope: {value:true},
+            luxometer: {value:true},
             keys: {value:true}
         },
         inputs:0,                // set the number of inputs - only 0 or 1

--- a/hardware/sensorTag/79-sensorTag.js
+++ b/hardware/sensorTag/79-sensorTag.js
@@ -30,6 +30,7 @@ function sensorTagNode(n) {
     this.accelerometer = n.accelerometer;
     this.magnetometer = n.magnetometer;
     this.gyroscope = n.gyroscope;
+    this.lux = n.lux; // supported in sensortag 2
     this.keys = n.keys;
 
     if (this.uuid === "") {
@@ -87,6 +88,12 @@ function sensorTagNode(n) {
                    msg.payload = {'x': x, 'y': y, 'z': z};
                    node.send(msg);
                 });
+                sensorTag.enableLux(function(){});
+                sensorTag.on('LuxChange', function(lux){ // should be luxChange
+                    var msg = {'topic': node.topic + '/lux'};
+                    msg.payload = {'lux': lux};
+                    node.send(msg);
+                });
                 sensorTag.on('simpleKeyChange', function(left, right){
                    var msg = {'topic': node.topic + '/keys'};
                    msg.payload = {'left': left, 'right': right};
@@ -132,6 +139,11 @@ function enable(node) {
        node.stag.notifyGyroscope(function() {});
     } else {
        node.stag.unnotifyGyroscope(function() {});
+    }
+    if (node.lux) {
+        node.stag.notifyLux(function() {});
+    } else {
+        node.stag.unnotifyLux(function() {});
     }
     if (node.keys) {
        node.stag.notifySimpleKey(function() {});


### PR DESCRIPTION
This is not ready to merge yet, but for the sake of capturing a snapshot of the work (and to point out how small the change is) I'm creating a pull request.

The TI Sensortag 2 is a new device that has a very similar interface to the TI Sensortag. It supports a couple of new sensors, include a luxometer for measuring light levels that is supported by this patch.

To make this work there's a new version of the node.js sensortag library that's being worked on, and that discussion is here:

https://github.com/sandeepmistry/node-sensortag/issues/34

This patch adds a new checkbox node to turn on the luxometer, and reports values on the sensorTag/lux channel.  If you're using the original sensorTag, you'll want to keep the checkbox unchecked.