### PR TITLE
added msg.params as an option for twitter out node

### DIFF
--- a/social/twitter/27-twitter.html
+++ b/social/twitter/27-twitter.html
@@ -204,6 +204,9 @@
     <p>To send a Direct Message (DM) - use a payload like "D {username} {message}"</p>
     <p>If <b>msg.media</b> exists and is a Buffer object, this node will treat it
        as an image and attach it to the tweet.</p>
+    <p>If <b>msg.params</b> exists and is a set of field: value pairs, this node will treat it as 
+       parameters for the update request</p>
+
 </script>
 
 <script type="text/javascript">

--- a/social/twitter/27-twitter.js
+++ b/social/twitter/27-twitter.js
@@ -313,7 +313,8 @@ module.exports = function(RED) {
                         form.append("media[]",msg.media,{filename:"image"});
 
                     } else {
-                        twit.updateStatus(msg.payload, function (err, data) {
+                        if (typeof msg.params === 'undefined') { msg.params = {};}
+                        twit.updateStatus(msg.payload, msg.params, function (err, data) {
                             if (err) {
                                 node.status({fill:"red",shape:"ring",text:RED._("twitter.status.failed")});
                                 node.error(err,msg);


### PR DESCRIPTION
Added support for the "twitter out" node to be able to support additional parameters to twitter. For example twitter needs 'in_reply_to_status_id' field to be set to the value of the original tweet if you want to reply to an existing message. 
it can be set as msg : { params: { in_reply_to_status_id: msg.tweet.id_str })
Other parameters can be found at https://dev.twitter.com/rest/reference/post/statuses/update
