### PR TITLE
fix the version of node-sensortag lib and bump version

### DIFF
--- a/hardware/sensorTag/package.json
+++ b/hardware/sensorTag/package.json
@@ -1,10 +1,10 @@
 {
     "name": "node-red-node-sensortag",
     "description": "A Node-RED node to read data from a TI SensorTag",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "keywords" : ["node-red","sensortag"],
     "dependencies": {
-        "sensortag" : "0.1.9"
+        "sensortag" : "~1.0.1"
     },
     "license": "Apache-2.0",
     "repository" : {


### PR DESCRIPTION
Updated the sensortag lib to one that supports the mkii sensortags