### PR TITLE
fix for OAuth on older browsers (e.g. Epiphany on Pi)

### DIFF
--- a/social/twitter/27-twitter.js
+++ b/social/twitter/27-twitter.js
@@ -351,7 +351,7 @@ module.exports = function(RED) {
             } else {
                 credentials.oauth_token = oauth_token;
                 credentials.oauth_token_secret = oauth_token_secret;
-                res.redirect('https://twitter.com/oauth/authorize?oauth_token='+oauth_token)
+                res.redirect('https://api.twitter.com/oauth/authorize?oauth_token='+oauth_token)
                 RED.nodes.addCredentials(req.params.id,credentials);
             }
         });


### PR DESCRIPTION
This tiny change fixes an issue with the Twitter node on devices like the Raspberry Pi.

Previously, the authentication step went to twitter.com, which redirected to mobile.twitter.com on older Webkit versions, where the oauth pin step is not supported, leaving the developer unable to add Twitter credentials.

With the change, it now sends the user directly to api.twitter.com which will work in browsers like the Epiphany version shipped in Raspbian.

Confirmed to work as a fix on a Pi Zero with latest Raspbian.