### PR TITLE
Fixes fatal server crash

### DIFF
--- a/io/mdns/mdns.js
+++ b/io/mdns/mdns.js
@@ -25,7 +25,11 @@ module.exports = function(RED) {
         RED.nodes.createNode(this, n);
         this.topic = n.topic || "";
         this.service = n.service;
-        var browser = mdns.createBrowser(this.service);
+        var sequence = [
+        	mdns.rst.DNSServiceResolve()
+        	, mdns.rst.getaddrinfo({families: [4] })
+        ];
+        var browser = mdns.createBrowser(this.service,{resolverSequence: sequence});
         var node = this;
 
         browser.on('serviceUp', function(service) {


### PR DESCRIPTION
On Ubuntu (15.10) I get a crash as soon as I add the mdns node to my flow and deploy the flow. After that I have to delete the node out of the flow file, manually, in a text editor to make the flow not crash the server.

The server crashes with the following message:
``
10 Dec 15:16:16 - Error: getaddrinfo -3008
    at errnoException (/usr/lib/node_modules/node-red/node_modules/node-red-node-discovery/node_modules/mdns/lib/resolver_sequence_tasks.js:199:11)
    at getaddrinfo_complete (/usr/lib/node_modules/node-red/node_modules/node-red-node-discovery/node_modules/mdns/lib/resolver_sequence_tasks.js:112:10)
    at GetAddrInfoReqWrap.oncomplete (/usr/lib/node_modules/node-red/node_modules/node-red-node-discovery/node_modules/mdns/lib/resolver_sequence_tasks.js:120:9)
``

I had the same error in my own node.js application that uses mdns. This change fixes the issue.