### PR TITLE
Add support for pushover sound selection.

### DIFF
--- a/social/pushover/57-pushover.html
+++ b/social/pushover/57-pushover.html
@@ -47,8 +47,8 @@
 
 <script type="text/x-red" data-help-name="pushover">
     <p>Uses Pushover to push the <b>msg.payload</b> to a device that has the Pushover app installed.</p>
-    <p>Optionally uses <b>msg.topic</b> to set the title, <b>msg.device</b> to set the device, and <b>msg.priority</b>
-    to set the priority, if not already set in the properties.</p>
+    <p>Optionally uses <b>msg.topic</b> to set the title, <b>msg.device</b> to set the device, <b>msg.priority</b>
+    to set the priority, and <b>msg.sound</b> to set a named sound, if not already set in the properties.</p>
     <p>The User-key and API-token are stored in a separate credentials file.</p>
     <p>Uses Pushover. See <i><a href="https://pushover.net" target="_new">this link</a></i> for more details.</p>
 </script>

--- a/social/pushover/57-pushover.html
+++ b/social/pushover/57-pushover.html
@@ -28,6 +28,34 @@
         <input type="text" id="node-input-priority" placeholder="0" style="width:50px;">
     </div>
     <div class="form-row">
+        <label for="node-input-sound"><i class="fa fa-bell"></i> Sound</label>
+        <select id="node-input-sound">
+            <option></option>
+            <option>pushover</option>
+            <option>bike</option>
+            <option>bugle</option>
+            <option>cashregister</option>
+            <option>classical</option>
+            <option>cosmic</option>
+            <option>falling</option>
+            <option>gamelan</option>
+            <option>incoming</option>
+            <option>intermission</option>
+            <option>magic</option>
+            <option>mechanical</option>
+            <option>pianobar</option>
+            <option>siren</option>
+            <option>spacealarm</option>
+            <option>tugboat</option>
+            <option>alien</option>
+            <option>climb</option>
+            <option>persistent</option>
+            <option>echo</option>
+            <option>updown</option>
+            <option>none</option>
+        </select>
+    </div>
+    <div class="form-row">
         <label for="node-input-deviceid"><i class="fa fa-user"></i> User key</label>
         <input type="text" id="node-input-deviceid">
     </div>
@@ -42,7 +70,8 @@
     </div>
     <div class="form-tips" id="node-tip">Tip: Leave title blank to set using <b>msg.topic</b>.<br/>
     Leave device blank to send to all devices, or to set using <b>msg.device</b>.<br/>
-    Leave priority blank to set using <b>msg.priority</b>. Supports priorities 2, 1, 0, -1, and -2.</div>
+    Leave priority blank to set using <b>msg.priority</b>. Supports priorities 2, 1, 0, -1, and -2.<br/>
+    Leave sound blank to use the default, or set using <b>msg.sound</b>.</div>
 </script>
 
 <script type="text/x-red" data-help-name="pushover">
@@ -60,7 +89,8 @@
             name: {value:""},
             device: {value:""},
             title: {value:""},
-            priority: {value:0}
+            priority: {value:0},
+            sound: {value:""}
         },
         credentials: {
             deviceid: {type:"text"},

--- a/social/pushover/57-pushover.js
+++ b/social/pushover/57-pushover.js
@@ -24,6 +24,8 @@ module.exports = function(RED) {
         this.title = n.title;
         this.device = n.device;
         this.priority = n.priority;
+        this.sound = n.sound;
+        if (this.sound === '') { this.sound = null; }
         var credentials = this.credentials;
         if ((credentials) && (credentials.hasOwnProperty("pushkey"))) { this.pushkey = credentials.pushkey; }
         else { this.error("No Pushover api token set"); }
@@ -45,7 +47,7 @@ module.exports = function(RED) {
             var titl = this.title || msg.topic || "Node-RED";
             var pri = this.priority || msg.priority || 0;
             var dev = this.device || msg.device;
-            var sound = msg.sound || null;
+            var sound = this.sound || msg.sound || null;
             if (isNaN(pri)) {pri=0;}
             if (pri > 2) {pri = 2;}
             if (pri < -2) {pri = -2;}

--- a/social/pushover/57-pushover.js
+++ b/social/pushover/57-pushover.js
@@ -45,6 +45,7 @@ module.exports = function(RED) {
             var titl = this.title || msg.topic || "Node-RED";
             var pri = this.priority || msg.priority || 0;
             var dev = this.device || msg.device;
+            var sound = msg.sound || null;
             if (isNaN(pri)) {pri=0;}
             if (pri > 2) {pri = 2;}
             if (pri < -2) {pri = -2;}
@@ -61,6 +62,7 @@ module.exports = function(RED) {
                     expire: 600
                 };
                 if (dev) { pushmsg.device = dev; }
+                if (typeof(sound) === 'string') { pushmsg.sound = sound; }
                 //node.log("Sending "+JSON.stringify(pushmsg));
                 pusher.send( pushmsg, function(err, response) {
                     if (err) { node.error("Pushover Error: "+err); }


### PR DESCRIPTION
Pushover supports a list of [notification sounds](https://pushover.net/api#sounds) to select from when pushing a notification.

This PR extends `PushoverNode` to honor the optional `msg.sound` field for this purpose.
If `msg.sound` is specified and contains a string it will be passed as the sound parameter.
If it's not set or not a valid string the same behavior as before is used.