### PR TITLE
Update 145-BBB-hardware.js

### DIFF
--- a/hardware/BBB/145-BBB-hardware.js
+++ b/hardware/BBB/145-BBB-hardware.js
@@ -65,7 +65,7 @@ module.exports = function (RED) {
         // measurements, then divides the total number, applies output scaling and
         // sends the result
         var analogReadCallback = function (err, x) {
-            sum = sum + x.value;
+            sum = sum + Number(x);
             count = count - 1;
             if (count > 0) {
                 bonescript.analogRead(node._pin, analogReadCallback);


### PR DESCRIPTION
"x.value" appears to be undefined, which in my case lead to a crash of Node-Red.
```
TypeError: Cannot read property 'output' of undefined
    at AnalogueInputNode.analogReadCallback (/root/.node-red/node_modules/node-red-node-beaglebone/145-BBB-hardware.js:85:54)
    at onReadAIN (/root/.node-red/node_modules/node-red-node-beaglebone/node_modules/octalbonescript/lib/analog.js:33:17)
    at fs.js:273:14
    at /usr/lib/node_modules/node-red/node_modules/fs-extra/node_modules/graceful-fs/graceful-fs.js:42:10
    at Object.oncomplete (fs.js:108:15)
```