### PR TITLE
Added support for sending and receiving strings

### DIFF
--- a/hardware/Arduino/35-arduino.html
+++ b/hardware/Arduino/35-arduino.html
@@ -27,6 +27,7 @@
         <select type="text" id="node-input-state" style="width: 150px;">
             <option value="INPUT" data-i18n="arduino.state.in.digital"></option>
             <option value="ANALOG" data-i18n="arduino.state.in.analogue"></option>
+			      <option value="STRING" data-i18n="arduino.state.in.string"></option>
         </select>
     </div>
     <div class="form-row">
@@ -83,6 +84,7 @@
             <option value="OUTPUT" data-i18n="arduino.state.out.digital"></option>
             <option value="PWM" data-i18n="arduino.state.out.analogue"></option>
             <option value="SERVO" data-i18n="arduino.state.out.servo"></option>
+			      <option value="STRING" data-i18n="arduino.state.out.string"></option>
         </select>
     </div>
     <div class="form-row">

--- a/hardware/Arduino/locales/en-US/35-arduino.json
+++ b/hardware/Arduino/locales/en-US/35-arduino.json
@@ -19,13 +19,13 @@
             "in": {
                 "digital": "Digital pin",
                 "analogue": "Analogue pin",
-				"string": "String"
+		"string": "String"
             },
             "out": {
                 "digital": "Digital (0/1)",
                 "analogue": "Analogue (0-255)",
                 "servo": "Servo (0-180)",
-				"string": "String"
+		"string": "String"
             }
         },
         "tip": {

--- a/hardware/Arduino/locales/en-US/35-arduino.json
+++ b/hardware/Arduino/locales/en-US/35-arduino.json
@@ -18,12 +18,14 @@
         "state": {
             "in": {
                 "digital": "Digital pin",
-                "analogue": "Analogue pin"
+                "analogue": "Analogue pin",
+				"string": "String"
             },
             "out": {
                 "digital": "Digital (0/1)",
                 "analogue": "Analogue (0-255)",
-                "servo": "Servo (0-180)"
+                "servo": "Servo (0-180)",
+				"string": "String"
             }
         },
         "tip": {


### PR DESCRIPTION
Added support for sending and receiving strings. The modifications uses the ability to send SysEx messages supported in arduino-firmata.js library. The string is encoded as a SysEx message of type 0x71 as specified in Firmata protocol.