### PR TITLE
SQL error with HTTP request

### DIFF
--- a/storage/mysql/68-mysql.js
+++ b/storage/mysql/68-mysql.js
@@ -103,8 +103,11 @@ module.exports = function(RED) {
                     //console.log("query:",msg.topic);
                     var bind = Array.isArray(msg.payload) ? msg.payload : [];
                     node.mydbConfig.connection.query(msg.topic, bind, function(err, rows) {
-                        if (err) { node.error(err,msg); }
-                        else {
+                        if (err) {
+							node.warn(err);
+							msg.error = err;
+							node.send(msg);
+						}else {
                             msg.payload = rows;
                             node.send(msg);
                         }


### PR DESCRIPTION
In the case the SQL node is in a flow with http in and out, the flow end
in case of error but the http client is waiting for an answer. So we
must not endded the flow but send back the error.