### PR TITLE
rbe: always remember previous value

### DIFF
--- a/function/rbe/rbe.js
+++ b/function/rbe/rbe.js
@@ -59,16 +59,15 @@ module.exports = function(RED) {
                         if (!node.previous.hasOwnProperty(t)) { node.previous[t] = n - node.gap; }
                         if (Math.abs(n - node.previous[t]) >= node.gap) {
                             if (this.func === "deadband") {
-                                node.previous[t] = n;
                                 node.send(msg);
                             }
                         }
                         else {
                             if (this.func === "narrowband") {
-                                node.previous[t] = n;
                                 node.send(msg);
                             }
                         }
+                        node.previous[t] = n;
                     }
                     else {
                         node.warn(RED._("rbe.warn.nonumber"));


### PR DESCRIPTION
This change addresses https://github.com/node-red/node-red-nodes/issues/192

Previously the rbe node was only "remembering" the last numerical value it saw if it forwarded the message. This change means it always remembers the previous value, even if it blocks the message.