### PR TITLE
Fixed "update" operation

### DIFF
--- a/storage/mongodb/66-mongodb.js
+++ b/storage/mongodb/66-mongodb.js
@@ -124,7 +124,7 @@ module.exports = function(RED) {
                             }
                         } else if (node.operation === "update") {
                             if (typeof msg.payload !== "object") {
-                                msg.payload = {"payload": msg.payload};
+                                msg.payload = JSON.parse(msg.payload);
                             }
                             var query = msg.query || {};
                             var payload = msg.payload || {};


### PR DESCRIPTION
"Update" operation was converting string payloads into an object by adding the "payload" key.  I believe we just want the value of the payload object.  So instead, the JSON.parse function was used to convert the payload string into an object without adding a "payload" key.