### PR TITLE
Fixed #222 - RFC error with invalid FROM address with userid conf

### DIFF
--- a/social/email/61-email.html
+++ b/social/email/61-email.html
@@ -70,8 +70,8 @@
 
 <script type="text/x-red" data-help-name="e-mail">
     <p>Sends the <code>msg.payload</code> as an email, with a subject of <code>msg.topic</code>.</p>
-	<p>You may optionally set <code>msg.from</code> in the payload which will override the <code>node.userid</code> 
-	default value.</p>
+    <p>You may optionally set <code>msg.from</code> in the payload which will override the <code>node.userid</code> 
+    default value.</p>
     <p>The default message recipient can be configured in the node, if it is left
     blank it should be set using the <code>msg.to</code> property of the incoming message. If left blank
     you can also specify <code>msg.cc</code> and/or <code>msg.bcc</code> properties.</p>
@@ -135,8 +135,8 @@
         </select>
     </div>
     <div class="form-row">
-		<label for="node-input-useSSL"><i class="fa fa-lock"></i> <span data-i18n="email.label.useSSL"></span></label>
-		<input type="checkbox" id="node-input-useSSL" style="width: auto;">
+        <label for="node-input-useSSL"><i class="fa fa-lock"></i> <span data-i18n="email.label.useSSL"></span></label>
+        <input type="checkbox" id="node-input-useSSL" style="width: auto;">
     </div>
     <div class="form-row">
         <label for="node-input-server"><i class="fa fa-globe"></i> <span data-i18n="email.label.server"></span></label>
@@ -159,7 +159,7 @@
         <input type="text" id="node-input-box">
     </div>
     <div class="form-row node-input-disposition">
-		    <label for="node-input-disposition"><i class="fa fa-trash"></i> <span data-i18n="email.label.disposition"></span></label>
+            <label for="node-input-disposition"><i class="fa fa-trash"></i> <span data-i18n="email.label.disposition"></span></label>
         <select type="text" id="node-input-disposition">
             <option value="None" selected="selected">None</option>
             <option value="Read">Mark Read/Answered</option>

--- a/social/email/61-email.html
+++ b/social/email/61-email.html
@@ -70,6 +70,8 @@
 
 <script type="text/x-red" data-help-name="e-mail">
     <p>Sends the <code>msg.payload</code> as an email, with a subject of <code>msg.topic</code>.</p>
+	<p>You may optionally set <code>msg.from</code> in the payload which will override the <code>node.userid</code> 
+	default value.</p>
     <p>The default message recipient can be configured in the node, if it is left
     blank it should be set using the <code>msg.to</code> property of the incoming message. If left blank
     you can also specify <code>msg.cc</code> and/or <code>msg.bcc</code> properties.</p>

--- a/social/email/61-email.js
+++ b/social/email/61-email.js
@@ -86,7 +86,7 @@ module.exports = function(RED) {
                     if (msg.to && node.name && (msg.to !== node.name)) {
                         node.warn(RED._("node-red:common.errors.nooverride"));
                     }
-                    var sendopts = { from: node.userid };   // sender address
+                    var sendopts = { from: ((msg.from) ? msg.from : node.userid) };   // sender address
                     sendopts.to = node.name || msg.to; // comma separated list of addressees
                     if (node.name === "") {
                         sendopts.cc = msg.cc;

--- a/social/email/README.md
+++ b/social/email/README.md
@@ -39,7 +39,9 @@ Uses the *imap* npm module.
 
 ### Output
 
-Sends the `msg.payload` as an email, with a subject of `msg.topic`.
+Sends the `msg.payload` as an email, with a subject of `msg.topic`. You may 
+optionally override the from email address by setting `msg.from` otherwise the 
+node will use the `node.userid` setting.
 
 The default message recipient can be configured in the node, if it is left
 blank it should be set using the `msg.to` property of the incoming message.


### PR DESCRIPTION
Added ability for user-defined `from` address in the `msg.payload`.  If `from` not in `msg.payload` then will default to `userid` but allowing override in case of #222 where `userid` is not a fully-qualified email address but a 3rd-party provider username (i.e. Sendgrid).

## Example usage
~~~
msg.payload = {
    ...
    "payload": {
        "to": msg.newRecord.recipients.map(function(email){
            return {"email": [{"value": email}]};
        }), 
        "from": "No-Reply Address <no-reply@domain.com>",
        "title": msg.newRecord.title,
        "body": msg.newRecord.body
    }
};
~~~