### PR TITLE
Added support for 'url' and 'url_title' for Pushover

### DIFF
--- a/social/pushover/57-pushover.js
+++ b/social/pushover/57-pushover.js
@@ -48,6 +48,8 @@ module.exports = function(RED) {
             var pri = this.priority || msg.priority || 0;
             var dev = this.device || msg.device;
             var sound = this.sound || msg.sound || null;
+            var url = this.url || msg.url || null;
+            var url_title = this.url_title || msg.url_title || null;
             if (isNaN(pri)) {pri=0;}
             if (pri > 2) {pri = 2;}
             if (pri < -2) {pri = -2;}
@@ -65,6 +67,8 @@ module.exports = function(RED) {
                 };
                 if (dev) { pushmsg.device = dev; }
                 if (typeof(sound) === 'string') { pushmsg.sound = sound; }
+                if (typeof(url) === 'string') { pushmsg.url = url; }
+                if (typeof(url_title) === 'string') { pushmsg.url_title = url_title; }
                 //node.log("Sending "+JSON.stringify(pushmsg));
                 pusher.send( pushmsg, function(err, response) {
                     if (err) { node.error("Pushover Error: "+err); }

--- a/social/pushover/README.md
+++ b/social/pushover/README.md
@@ -16,8 +16,8 @@ Usage
 
 Uses Pushover to push the `msg.payload` to a device that has the Pushover app installed.
 
-Optionally uses `msg.topic` to set the title, `msg.device` to set the device
-and `msg.priority` to set the priority, if not already set in the properties.
+Optionally uses `msg.topic` to set the title, `msg.device` to set the device, `msg.priority` to set the priority,
+`msg.url` to add a web address and `msg.url_title` to add a url title if not already set in the properties.
 
 The User-key and API-token are stored in a separate credentials file.
 


### PR DESCRIPTION
Added support for `url` and `url_title` properties of the Pushover API message object. These where missing in the current version. There is actually no other way to use these features with pushover. It's just two other optional properties in the message object. I've used the same coding-style as for the other properties in the original file.

Further information about these properties can be found in the docs:
https://pushover.net/api