### PR TITLE
remove firmata/node_modules path in require('serialport')

### DIFF
--- a/hardware/Arduino/35-arduino.js
+++ b/hardware/Arduino/35-arduino.js
@@ -3,7 +3,7 @@ module.exports = function(RED) {
     "use strict";
 
     var Board = require('firmata');
-    var SP = require('firmata/node_modules/serialport');
+    var SP = require('serialport');
 
     // The Board Definition - this opens (and closes) the connection
     function ArduinoNode(n) {


### PR DESCRIPTION
serialport is not found when installing the npm module local (instead of 'npm install node-red-node-arduino -g')
require will look by default in the node_modules folder