### PR TITLE
Add user's auth token when authenticating Twitter (#253)

### DIFF
--- a/social/twitter/27-twitter.html
+++ b/social/twitter/27-twitter.html
@@ -32,9 +32,27 @@
                 if (pathname.slice(-1) != "/") {
                     pathname += "/";
                 }
+
+                // If the Node-RED user is logged in, add their authentication token as a
+                // query parameter to both the button's link and the callback.
+                var authTokens = RED.settings.get('auth-tokens');
+                var accessToken = authTokens && authTokens.access_token;
+
                 var callback = encodeURIComponent(location.protocol+"//"+location.hostname+":"+location.port+pathname+"twitter-credentials/"+twitterConfigNodeId+"/auth/callback");
+
+
+                if (accessToken) {
+                    callback += encodeURIComponent('?access_token=' + accessToken);
+                } 
+
+                var link = 'twitter-credentials/'+twitterConfigNodeId+'/auth?callback='+callback;
+
+                if (accessToken) {
+                    link += '&access_token=' + accessToken;
+                }
+
                 $("#node-config-dialog-ok").button("disable");
-                $("#node-config-twitter-row").html('<div style="text-align: center; margin-top: 20px; "><a class="btn" id="node-config-twitter-start" href="twitter-credentials/'+twitterConfigNodeId+'/auth?callback='+callback+'" target="_blank">'+clickhere+'</a></div>');
+                $("#node-config-twitter-row").html('<div style="text-align: center; margin-top: 20px; "><a class="btn" id="node-config-twitter-start" href="'+link+'" target="_blank">'+clickhere+'</a></div>');
                 $("#node-config-twitter-start").click(function() {
                     twitterConfigNodeIntervalId = window.setTimeout(pollTwitterCredentials,2000);
                 });

--- a/social/twitter/27-twitter.html
+++ b/social/twitter/27-twitter.html
@@ -33,27 +33,24 @@
                     pathname += "/";
                 }
 
-                // If the Node-RED user is logged in, add their authentication token as a
-                // query parameter to both the button's link and the callback.
-                var authTokens = RED.settings.get('auth-tokens');
-                var accessToken = authTokens && authTokens.access_token;
-
                 var callback = encodeURIComponent(location.protocol+"//"+location.hostname+":"+location.port+pathname+"twitter-credentials/"+twitterConfigNodeId+"/auth/callback");
 
-
-                if (accessToken) {
-                    callback += encodeURIComponent('?access_token=' + accessToken);
-                } 
-
-                var link = 'twitter-credentials/'+twitterConfigNodeId+'/auth?callback='+callback;
-
-                if (accessToken) {
-                    link += '&access_token=' + accessToken;
-                }
-
                 $("#node-config-dialog-ok").button("disable");
-                $("#node-config-twitter-row").html('<div style="text-align: center; margin-top: 20px; "><a class="btn" id="node-config-twitter-start" href="'+link+'" target="_blank">'+clickhere+'</a></div>');
+                $("#node-config-twitter-row").html('<div style="text-align: center; margin-top: 20px; "><a class="btn" id="node-config-twitter-start" href="#" >'+clickhere+'</a></div>');
+
                 $("#node-config-twitter-start").click(function() {
+                    // The button's target must be made with an AJAX request. If there's a user
+                    // logged into Node-RED, then the authorization header must be added to the request, so a simple
+                    // anchor href link cannot be used. 
+                    
+                    $.ajax({
+                        url: 'twitter-credentials/'+twitterConfigNodeId+'/auth?callback='+callback,
+                        success: function(body, textStatus, jqXHR) {
+                            // The response's body has the Twitter address with which to authorize the user.
+                            window.open(body, '_blank');
+                        }
+                   });
+
                     twitterConfigNodeIntervalId = window.setTimeout(pollTwitterCredentials,2000);
                 });
             }

--- a/social/twitter/27-twitter.js
+++ b/social/twitter/27-twitter.js
@@ -472,13 +472,18 @@ module.exports = function(RED) {
             else {
                 credentials.oauth_token = oauth_token;
                 credentials.oauth_token_secret = oauth_token_secret;
-                res.redirect('https://api.twitter.com/oauth/authorize?oauth_token='+oauth_token)
+
+				// Send the authorization URL in the body, not as a 302 redirect.
+                // The client will pass the URL to a new window. A full AJAX request and 200 response
+                // is required to get through the authorization check in this endpoint.
+                res.send('https://api.twitter.com/oauth/authorize?oauth_token='+oauth_token)
+
                 RED.nodes.addCredentials(req.params.id,credentials);
             }
         });
     });
 
-    RED.httpAdmin.get('/twitter-credentials/:id/auth/callback', RED.auth.needsPermission('twitter.read'), function(req, res, next) {
+    RED.httpAdmin.get('/twitter-credentials/:id/auth/callback', function(req, res, next) {
         var credentials = RED.nodes.getCredentials(req.params.id);
         credentials.oauth_verifier = req.query.oauth_verifier;
 

--- a/social/twitter/27-twitter.js
+++ b/social/twitter/27-twitter.js
@@ -473,7 +473,7 @@ module.exports = function(RED) {
                 credentials.oauth_token = oauth_token;
                 credentials.oauth_token_secret = oauth_token_secret;
 
-				// Send the authorization URL in the body, not as a 302 redirect.
+                // Send the authorization URL in the body, not as a 302 redirect.
                 // The client will pass the URL to a new window. A full AJAX request and 200 response
                 // is required to get through the authorization check in this endpoint.
                 res.send('https://api.twitter.com/oauth/authorize?oauth_token='+oauth_token)
@@ -484,7 +484,7 @@ module.exports = function(RED) {
     });
 
     RED.httpAdmin.get('/twitter-credentials/:id/auth/callback', function(req, res, next) {
-		// This endpoint doesn't have the RED.auth.needsPermission() middleware, because it's 
+        // This endpoint doesn't have the RED.auth.needsPermission() middleware, because it's 
         // being called from the Twitter authorization page, and can't add the user's 
         // Node-RED authorization bearer token in the request header.
         var credentials = RED.nodes.getCredentials(req.params.id);

--- a/social/twitter/27-twitter.js
+++ b/social/twitter/27-twitter.js
@@ -484,6 +484,9 @@ module.exports = function(RED) {
     });
 
     RED.httpAdmin.get('/twitter-credentials/:id/auth/callback', function(req, res, next) {
+		// This endpoint doesn't have the RED.auth.needsPermission() middleware, because it's 
+        // being called from the Twitter authorization page, and can't add the user's 
+        // Node-RED authorization bearer token in the request header.
         var credentials = RED.nodes.getCredentials(req.params.id);
         credentials.oauth_verifier = req.query.oauth_verifier;
 


### PR DESCRIPTION
This PR addresses issue #253, or at least one instance of it.

When initiating the Twitter authentication process, I've added the Node-RED user's access token as a query parameter. This had to be added to both the initial request and the callback URL. A query parameter named "access_token" is supported by the [passport-http-bearer](https://www.npmjs.com/package/passport-bearer-strategy) module used by Node-RED. This then allows the RED.auth.needsPermission() check to pass on both of the Twitter node's server endpoints.

The only other ways to get through the "passport-http-bearer" check is with the user's bearer token in the HTTP header or the body. I don't think either of these would work with the approach used by the Twitter node.

However, I'm uncomfortable that the Node-RED user's bearer token is being passed in the callback URL. That's going to Twitter and back. If that is indeed unacceptable, we can close this PR.

Maybe this needs a cookie-based approach or Twitter's [PIN-based](https://dev.twitter.com/oauth/pin-based) option, both of which would be a big change.

Maybe a compromise would be to remove the authentication check on the callback endpoint.
