### PR TITLE
fix twilio global credentials

### DIFF
--- a/social/twilio/56-twilio.js
+++ b/social/twilio/56-twilio.js
@@ -10,7 +10,7 @@ module.exports = function(RED) {
     }
 
     RED.httpAdmin.get('/twilio-api/global', RED.auth.needsPermission("twilio.read"), function(req,res) {
-        res.json({hasToken:!(twiliokey && twiliokey.account && twiliokey.authtoken)});
+        res.json({hasToken:!!(twiliokey && twiliokey.account && twiliokey.authtoken)});
     });
 
     function TwilioAPINode(n) {


### PR DESCRIPTION
I found that the "Use Global Credentials" option was available by default. But upon providing global credentials in the settings.js file as instructed, that option disappeared. I dug in a bit and found that the `/twilio-api/global` route was returning `hasToken: false` when it had the account and auth token from settings. It should instead be returning `hasToken: true`. An extra `!` flips it around correctly.