### PR TITLE
Allow msg to set parameters for snmp nodes.

### DIFF
--- a/io/snmp/snmp.html
+++ b/io/snmp/snmp.html
@@ -37,7 +37,7 @@
         category: 'network-input',
         color:"YellowGreen",
         defaults: {
-            host: {value:"",required:true},
+            host: {value:""},
             community: {value:"public",required:true},
             version: {value:"1",required:true},
             oids: {value:""},
@@ -94,7 +94,7 @@
         category: 'network-input',
         color:"YellowGreen",
         defaults: {
-            host: {value:"",required:true},
+            host: {value:""},
             community: {value:"public",required:true},
             version: {value:"1",required:true},
             oids: {value:""},
@@ -150,7 +150,7 @@
         category: 'network-input',
         color:"YellowGreen",
         defaults: {
-            host: {value:"",required:true},
+            host: {value:""},
             community: {value:"public",required:true},
             version: {value:"1",required:true},
             oids: {value:""},
@@ -208,7 +208,7 @@
         category: 'network-input',
         color:"YellowGreen",
         defaults: {
-            host: {value:"",required:true},
+            host: {value:""},
             community: {value:"public",required:true},
             version: {value:"1",required:true},
             oids: {value:""},

--- a/io/snmp/snmp.js
+++ b/io/snmp/snmp.js
@@ -14,12 +14,12 @@ module.exports = function(RED) {
         this.on("input",function(msg) {
             var oids = node.oids || msg.oid;
             if (oids) {
-				if (msg.host && node.host || msg.community && node.community) {
-					node.warn(RED._("common.errors.nooverride"));
-				}
-				var host = node.host || msg.host;
-				var community = node.community || msg.community;
-				node.session = snmp.createSession(host, community, {version: node.version});
+                if (msg.host && node.host || msg.community && node.community) {
+                    node.warn(RED._("common.errors.nooverride"));
+                }
+                var host = node.host || msg.host;
+                var community = node.community || msg.community;
+                node.session = snmp.createSession(host, community, {version: node.version});
                 node.session.get(oids.split(","), function(error, varbinds) {
                     if (error) {
                         node.error(error.toString(),msg);
@@ -47,10 +47,10 @@ module.exports = function(RED) {
         });
         
         this.on("close", function(){
-			if (node.session){
-				node.session.close();
-			}
-		});
+            if (node.session){
+                node.session.close();
+            }
+        });
     }
     RED.nodes.registerType("snmp",SnmpNode);
 
@@ -74,40 +74,40 @@ module.exports = function(RED) {
             if (oids) {
                 msg.oid = oids;
                 if (msg.host && node.host || msg.community && node.community) {
-					node.warn(RED._("common.errors.nooverride"));
-				}
-				var host = node.host || msg.host;
-				var community = node.community || msg.community;
-				node.session = snmp.createSession(host, community, {version: node.version});
+                    node.warn(RED._("common.errors.nooverride"));
+                }
+                var host = node.host || msg.host;
+                var community = node.community || msg.community;
+                node.session = snmp.createSession(host, community, {version: node.version});
                 node.session.table(oids, maxRepetitions, function(error, table) {
-					if (error) {
-						node.error(error.toString());
-					}
-					else {
-						var indexes = [];
-						for (var index in table) {
-							if (table.hasOwnProperty(index)) {
-								indexes.push(parseInt(index));
-							}
-						}
-						indexes.sort(sortInt);
-						for (var i = 0; i < indexes.length; i++) {
-							var columns = [];
-							for (var column in table[indexes[i]]) {
-								if (table[indexes[i]].hasOwnProperty(column)) {
-									columns.push(parseInt(column));
-								}
-							}
-							columns.sort(sortInt);
-							// console.log("row index = " + indexes[i]);
-							// for (var j = 0; j < columns.length; j++) {
-							//     console.log("  column " + columns[j] + " = " + table[indexes[i]][columns[j]]);
-							// }
-						}
-						msg.payload = table;
-						node.send(msg);
-					}
-				});
+                    if (error) {
+                        node.error(error.toString());
+                    }
+                    else {
+                        var indexes = [];
+                        for (var index in table) {
+                            if (table.hasOwnProperty(index)) {
+                                indexes.push(parseInt(index));
+                            }
+                        }
+                        indexes.sort(sortInt);
+                        for (var i = 0; i < indexes.length; i++) {
+                            var columns = [];
+                            for (var column in table[indexes[i]]) {
+                                if (table[indexes[i]].hasOwnProperty(column)) {
+                                    columns.push(parseInt(column));
+                                }
+                            }
+                            columns.sort(sortInt);
+                            // console.log("row index = " + indexes[i]);
+                            // for (var j = 0; j < columns.length; j++) {
+                            //     console.log("  column " + columns[j] + " = " + table[indexes[i]][columns[j]]);
+                            // }
+                        }
+                        msg.payload = table;
+                        node.send(msg);
+                    }
+                });
             }
             else {
                 node.warn("No oid to search for");
@@ -115,10 +115,10 @@ module.exports = function(RED) {
         });
         
         this.on("close", function(){
-			if (node.session){
-				node.session.close();
-			}
-		});
+            if (node.session){
+                node.session.close();
+            }
+        });
     }
     RED.nodes.registerType("snmp table",SnmpTNode);
 
@@ -147,24 +147,24 @@ module.exports = function(RED) {
         this.on("input",function(msg) {
             var oids = node.oids || msg.oid;
             if (oids) {
-				msg.oid = oids;
-				if (msg.host && node.host || msg.community && node.community) {
-					node.warn(RED._("common.errors.nooverride"));
-				}
-				var host = node.host || msg.host;
-				var community = node.community || msg.community;
-				node.session = snmp.createSession(host, community, {version: node.version});
+                msg.oid = oids;
+                if (msg.host && node.host || msg.community && node.community) {
+                    node.warn(RED._("common.errors.nooverride"));
+                }
+                var host = node.host || msg.host;
+                var community = node.community || msg.community;
+                node.session = snmp.createSession(host, community, {version: node.version});
                 node.session.subtree(msg.oid, maxRepetitions, feedCb, function(error) {
-					if (error) {
-						node.error(error.toString());
-					}
-					else {
-						msg.payload = response;
-						node.send(msg);
-						//Clears response
-						response.length = 0;
-					}
-				});
+                    if (error) {
+                        node.error(error.toString());
+                    }
+                    else {
+                        msg.payload = response;
+                        node.send(msg);
+                        //Clears response
+                        response.length = 0;
+                    }
+                });
             }
             else {
                 node.warn("No oid to search for");
@@ -172,10 +172,10 @@ module.exports = function(RED) {
         });
         
         this.on("close", function(){
-			if (node.session){
-				node.session.close();
-			}
-		});
+            if (node.session){
+                node.session.close();
+            }
+        });
     }
     RED.nodes.registerType("snmp subtree",SnmpSubtreeNode);
 
@@ -202,38 +202,38 @@ module.exports = function(RED) {
         }
 
         this.on("input",function(msg) {
-			node.msg = msg;
+            node.msg = msg;
             var oids = node.oids || msg.oid;
             if (oids) {
                 msg.oid = oids;
                 if (msg.host && node.host || msg.community && node.community) {
-					node.warn(RED._("common.errors.nooverride"));
-				}
-				var host = node.host || msg.host;
-				var community = node.community || msg.community;
-				node.session = snmp.createSession(host, community, {version: node.version});
+                    node.warn(RED._("common.errors.nooverride"));
+                }
+                var host = node.host || msg.host;
+                var community = node.community || msg.community;
+                node.session = snmp.createSession(host, community, {version: node.version});
                 node.session.walk(msg.oid, maxRepetitions, feedCb, function(error) {
-					if (error) {
-						node.error(error.toString());
-					}
-					else {
-						msg.payload = response;
-						node.send(msg);
-						//Clears response
-						response.length = 0;
-					}
-				});
+                    if (error) {
+                        node.error(error.toString());
+                    }
+                    else {
+                        msg.payload = response;
+                        node.send(msg);
+                        //Clears response
+                        response.length = 0;
+                    }
+                });
             }
             else {
                 node.warn("No oid to search for");
             }
         });
         
-		this.on("close", function(){
-			if (node.session){
-				node.session.close();
-			}
-		});
+        this.on("close", function(){
+            if (node.session){
+                node.session.close();
+            }
+        });
     }
     RED.nodes.registerType("snmp walker",SnmpWalkerNode);
 };


### PR DESCRIPTION
I've modified the snmp libraries so that the server and the community can be defined by the msg.

Error will be thrown if you try to override what was defined in the node.
Verified that the contents of msg is no longer clobbered.

Signed-off-by: Bryan Malyn <bimalyn@us.ibm.com>