### PR TITLE
Pisrf performance fix

### DIFF
--- a/hardware/PiSrf/nrsrf.py
+++ b/hardware/PiSrf/nrsrf.py
@@ -33,6 +33,12 @@ def Measure():
             Main()
     while GPIO.input(ECHO)==1:
         stop = time.time()
+        Dif = time.time() - realstart
+        if Dif > 5:
+            print("Ultrasonic Sensor Timed out, Restarting.")
+            time.sleep(0.4)
+            Main()
+
     elapsed = stop-start
     distance = (elapsed * 36000)/2
 
@@ -60,12 +66,20 @@ if len(sys.argv) > 1:
     while len(select.select([sys.stdin.fileno()], [], [], 0.0)[0])>0:
         os.read(sys.stdin.fileno(), 4096)
 
+    counter = 0
     while True:
         try:
             distance = int( Measure() + 0.5 )
             if distance != OLD:
                 print(distance)
                 OLD = distance
+                counter = 0
+            else:
+                counter += 1
+
+            if counter == 20:
+               raise Exception("Timeout reading ultrasonic sensor")
+                
             time.sleep(0.5)
         except:                     # try to clean up on exit
             print("0.0");

--- a/hardware/PiSrf/nrsrf.py
+++ b/hardware/PiSrf/nrsrf.py
@@ -66,20 +66,12 @@ if len(sys.argv) > 1:
     while len(select.select([sys.stdin.fileno()], [], [], 0.0)[0])>0:
         os.read(sys.stdin.fileno(), 4096)
 
-    counter = 0
     while True:
         try:
             distance = int( Measure() + 0.5 )
             if distance != OLD:
                 print(distance)
-                OLD = distance
-                counter = 0
-            else:
-                counter += 1
-
-            if counter == 20:
-               raise Exception("Timeout reading ultrasonic sensor")
-                
+                OLD = distance                
             time.sleep(0.5)
         except:                     # try to clean up on exit
             print("0.0");


### PR DESCRIPTION
Hi Dave, Nick,

I had connected a HC-SR04 ultrasone sensor to my Raspberry Pi 3 ( pin 7 = trigger / pin 11 = echo ) and it works like a charm.  Even when my sensor is unpowered but connected (to the GPIO pins), performance still looks good.

However when I enter (in the properties of my node-red-pisrf node) some pin numbers that are unconnected ( pin 16 = trigger / pin 18 = echo ), one of my 4 cores goes up to 100% (measured with my [cpu](https://www.npmjs.com/package/node-red-contrib-cpu) node):

![image](https://cloud.githubusercontent.com/assets/14224149/25785622/b76b8876-3385-11e7-852a-3c906fa6f74b.png)

Seems the Python script (spawned by the pisrf node) has a time-out check when waiting for a rising edge, but there is no timeout for a falling edge.   When I add the timeout, everything looks to be fine again:

![image](https://cloud.githubusercontent.com/assets/14224149/25785640/5992225e-3386-11e7-87a9-27a9010a3e82.png)

Note: I have used a time-out of 5 seconds.  However since the range of these kind of sensors is only about 4 meters, a timeout of 25 or 30 milliseconds should be sufficient.  When I change it to 0.2 (like in the existing check) it still seems to be working fine.  So please adjust the number to whatever you like.

Kind regards,
Bart Butenaers