### PR TITLE
SNMP Set Node

### DIFF
--- a/io/snmp/package.json
+++ b/io/snmp/package.json
@@ -1,6 +1,6 @@
 {
     "name"          : "node-red-node-snmp",
-    "version"       : "0.0.11",
+    "version"       : "0.0.12",
     "description"   : "A Node-RED node that looks for SNMP oids.",
     "dependencies"  : {
         "net-snmp"  : "^1.1.19"
@@ -23,6 +23,7 @@
     },
     "contributors": [
         { "name": "Mika Karalia" },
-        { "name": "Bryan Malyn" }
+        { "name": "Bryan Malyn" },
+        { "name": "Martin Schlienger"}
     ]
 }

--- a/io/snmp/snmp.html
+++ b/io/snmp/snmp.html
@@ -58,6 +58,60 @@
 </script>
 
 
+<script type="text/x-red" data-template-name="snmp set">
+    <div class="form-row">
+         <label for="node-input-host"><i class="fa fa-globe"></i> Host</label>
+         <input type="text" id="node-input-host" placeholder="localhost">
+    </div>
+    <div class="form-row">
+        <label for="node-input-community"><i class="fa fa-user"></i> Community</label>
+        <input type="text" id="node-input-community" placeholder="public">
+    </div>
+    <div class="form-row">
+        <label for="node-input-version"><i class="fa fa-bookmark"></i> Version</label>
+        <select type="text" id="node-input-version" style="width: 150px;">
+            <option value="1">v1</option>
+            <option value="2c">v2c</option>
+        </select>
+    </div>
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+</script>
+
+<script type="text/x-red" data-help-name="snmp set">
+    <p>Simple snmp Set node. Trigger by any input</p>
+    <p><code>msg.host</code> may contain the host.</p>
+    <p><code>msg.community</code> may contain the community.</p>
+    <p><code>msg.oids</code> must contain oids in JSON syntax according to net-snmp  [ { oid: "1.3.6.1.2.1.1.5.0", type: 4, value: "host1"} , { oid: ...} ]</p>
+    <p>The node will output <code>msg.payload</code> and <code>msg.oid</code>.</p>
+</script>
+
+<script type="text/javascript">
+    RED.nodes.registerType('snmp set',{
+        category: 'network-input',
+        color:"YellowGreen",
+        defaults: {
+            host: {value:""},
+            community: {value:"public",required:false},
+            version: {value:"1",required:false},
+            oids: {value:""},
+            name: {value:""}
+        },
+        inputs:1,
+        outputs:1,
+        icon: "snmp.png",
+        label: function() {
+            return this.name||"snmp set "+this.host;
+        },
+        labelStyle: function() {
+            return this.name?"node_label_italic":"";
+        }
+    });
+</script>
+
+
 <script type="text/x-red" data-template-name="snmp table">
     <div class="form-row">
          <label for="node-input-host"><i class="fa fa-globe"></i> Host</label>

--- a/io/snmp/snmp.js
+++ b/io/snmp/snmp.js
@@ -1,30 +1,29 @@
-
-module.exports = function(RED) {
+module.exports = function (RED) {
     "use strict";
     var snmp = require("net-snmp");
 
     function SnmpNode(n) {
-        RED.nodes.createNode(this,n);
+        RED.nodes.createNode(this, n);
         this.community = n.community;
         this.host = n.host;
         this.version = (n.version === "2c") ? snmp.Version2c : snmp.Version1;
-        this.oids = n.oids.replace(/\s/g,"");
+        this.oids = n.oids.replace(/\s/g, "");
         var node = this;
 
-        this.on("input",function(msg) {
+        this.on("input", function (msg) {
             var host = node.host || msg.host;
             var community = node.community || msg.community;
             var oids = node.oids || msg.oid;
             if (oids) {
-                node.session = snmp.createSession(host, community, {version: node.version});
-                node.session.get(oids.split(","), function(error, varbinds) {
+                node.session = snmp.createSession(host, community, { version: node.version });
+                node.session.get(oids.split(","), function (error, varbinds) {
                     if (error) {
-                        node.error(error.toString(),msg);
+                        node.error(error.toString(), msg);
                     }
                     else {
                         for (var i = 0; i < varbinds.length; i++) {
                             if (snmp.isVarbindError(varbinds[i])) {
-                                node.error(snmp.varbindError(varbinds[i]),msg);
+                                node.error(snmp.varbindError(varbinds[i]), msg);
                             }
                             else {
                                 if (varbinds[i].type == 4) { varbinds[i].value = varbinds[i].value.toString(); }
@@ -43,20 +42,72 @@ module.exports = function(RED) {
             }
         });
 
-        this.on("close", function() {
+        this.on("close", function () {
             if (node.session) {
                 node.session.close();
             }
         });
     }
-    RED.nodes.registerType("snmp",SnmpNode);
+    RED.nodes.registerType("snmp", SnmpNode);
 
-    function SnmpTNode(n) {
-        RED.nodes.createNode(this,n);
+
+    function SnmpSNode(n) {
+        RED.nodes.createNode(this, n);
         this.community = n.community;
         this.host = n.host;
         this.version = (n.version === "2c") ? snmp.Version2c : snmp.Version1;
-        this.oids = n.oids.replace(/\s/g,"");
+        var node = this;
+
+        this.on("input", function (msg) {
+			//I reverted priority between message host/community and config.
+            //it makes more sense to have msg host/community having prority, and default value be the ones in configured in the node.
+            //NB: as node.host seems mandatory in the other nodes, msg.host will never be taken into account.
+            var host = msg.host || node.host;
+            var community = msg.community || node.community;
+            var oids = msg.oids;
+            node.log(oids + ' ' + host + ' ' + msg.host+ community + msg.community);
+            if (oids) {
+                node.session = snmp.createSession(host, community, { version: node.version });
+                node.session.set(oids, function (error, varbinds) {
+                    if (error) {
+                        node.error(error.toString(), msg);
+                    }
+                    else {
+                        for (var i = 0; i < varbinds.length; i++) {
+                            if (snmp.isVarbindError(varbinds[i])) {
+                                node.error(snmp.varbindError(varbinds[i]), msg);
+                            }
+                            else {
+                                if (varbinds[i].type == 4) { varbinds[i].value = varbinds[i].value.toString(); }
+                                varbinds[i].tstr = snmp.ObjectType[varbinds[i].type];
+                                //node.log(varbinds[i].oid + "|" + varbinds[i].tstr + "|" + varbinds[i].value);
+                            }
+                        }
+                        msg.oid = oids;
+                        msg.payload = varbinds;
+                        node.send(msg);
+                    }
+                });
+            }
+            else {
+                node.warn("No oid(s) to set");
+            }
+        });
+
+        this.on("close", function () {
+            if (node.session) {
+                node.session.close();
+            }
+        });
+    }
+    RED.nodes.registerType("snmp set", SnmpSNode);
+
+    function SnmpTNode(n) {
+        RED.nodes.createNode(this, n);
+        this.community = n.community;
+        this.host = n.host;
+        this.version = (n.version === "2c") ? snmp.Version2c : snmp.Version1;
+        this.oids = n.oids.replace(/\s/g, "");
         var node = this;
         var maxRepetitions = 20;
 
@@ -66,14 +117,14 @@ module.exports = function(RED) {
             else { return 0; }
         }
 
-        this.on("input",function(msg) {
+        this.on("input", function (msg) {
             var host = node.host || msg.host;
             var community = node.community || msg.community;
             var oids = node.oids || msg.oid;
             if (oids) {
                 msg.oid = oids;
-                node.session = snmp.createSession(host, community, {version: node.version});
-                node.session.table(oids, maxRepetitions, function(error, table) {
+                node.session = snmp.createSession(host, community, { version: node.version });
+                node.session.table(oids, maxRepetitions, function (error, table) {
                     if (error) {
                         node.error(error.toString(), msg);
                     }
@@ -108,20 +159,20 @@ module.exports = function(RED) {
             }
         });
 
-        this.on("close", function() {
+        this.on("close", function () {
             if (node.session) {
                 node.session.close();
             }
         });
     }
-    RED.nodes.registerType("snmp table",SnmpTNode);
+    RED.nodes.registerType("snmp table", SnmpTNode);
 
     function SnmpSubtreeNode(n) {
-        RED.nodes.createNode(this,n);
+        RED.nodes.createNode(this, n);
         this.community = n.community;
         this.host = n.host;
         this.version = (n.version === "2c") ? snmp.Version2c : snmp.Version1;
-        this.oids = n.oids.replace(/\s/g,"");
+        this.oids = n.oids.replace(/\s/g, "");
         var node = this;
         var maxRepetitions = 20;
         var response = [];
@@ -133,19 +184,19 @@ module.exports = function(RED) {
                 }
                 else {
                     //console.log(varbinds[i].oid + "|" + varbinds[i].value);
-                    response.push({oid: varbinds[i].oid, value: varbinds[i].value});
+                    response.push({ oid: varbinds[i].oid, value: varbinds[i].value });
                 }
             }
         }
 
-        this.on("input",function(msg) {
+        this.on("input", function (msg) {
             var host = node.host || msg.host;
             var community = node.community || msg.community;
             var oids = node.oids || msg.oid;
             if (oids) {
                 msg.oid = oids;
-                node.session = snmp.createSession(host, community, {version: node.version});
-                node.session.subtree(msg.oid, maxRepetitions, feedCb, function(error) {
+                node.session = snmp.createSession(host, community, { version: node.version });
+                node.session.subtree(msg.oid, maxRepetitions, feedCb, function (error) {
                     if (error) {
                         node.error(error.toString(), msg);
                     }
@@ -162,20 +213,20 @@ module.exports = function(RED) {
             }
         });
 
-        this.on("close", function() {
+        this.on("close", function () {
             if (node.session) {
                 node.session.close();
             }
         });
     }
-    RED.nodes.registerType("snmp subtree",SnmpSubtreeNode);
+    RED.nodes.registerType("snmp subtree", SnmpSubtreeNode);
 
     function SnmpWalkerNode(n) {
-        RED.nodes.createNode(this,n);
+        RED.nodes.createNode(this, n);
         this.community = n.community;
         this.host = n.host;
         this.version = (n.version === "2c") ? snmp.Version2c : snmp.Version1;
-        this.oids = n.oids.replace(/\s/g,"");
+        this.oids = n.oids.replace(/\s/g, "");
         var node = this;
         var maxRepetitions = 20;
         var response = [];
@@ -187,20 +238,20 @@ module.exports = function(RED) {
                 }
                 else {
                     //console.log(varbinds[i].oid + "|" + varbinds[i].value);
-                    response.push({oid: varbinds[i].oid, value: varbinds[i].value});
+                    response.push({ oid: varbinds[i].oid, value: varbinds[i].value });
                 }
             }
         }
 
-        this.on("input",function(msg) {
+        this.on("input", function (msg) {
             node.msg = msg;
             var oids = node.oids || msg.oid;
             var host = node.host || msg.host;
             var community = node.community || msg.community;
             if (oids) {
                 msg.oid = oids;
-                node.session = snmp.createSession(host, community, {version: node.version});
-                node.session.walk(msg.oid, maxRepetitions, feedCb, function(error) {
+                node.session = snmp.createSession(host, community, { version: node.version });
+                node.session.walk(msg.oid, maxRepetitions, feedCb, function (error) {
                     if (error) {
                         node.error(error.toString(), msg);
                     }
@@ -217,11 +268,11 @@ module.exports = function(RED) {
             }
         });
 
-        this.on("close", function() {
+        this.on("close", function () {
             if (node.session) {
                 node.session.close();
             }
         });
     }
-    RED.nodes.registerType("snmp walker",SnmpWalkerNode);
+    RED.nodes.registerType("snmp walker", SnmpWalkerNode);
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "contributors": [
         {"name": "Dave Conway-Jones"},
         {"name": "Nick O'Leary"},
-        {"name": "Ben Hardill"}
+        {"name": "Ben Hardill"},
+	{"name": "Martin Schlienger}
     ],
     "keywords": [
         "Node-RED", "nodes", "iot", "ibm", "flow"

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "contributors": [
         {"name": "Dave Conway-Jones"},
         {"name": "Nick O'Leary"},
-        {"name": "Ben Hardill"},
-	{"name": "Martin Schlienger}
+        {"name": "Ben Hardill"}
     ],
     "keywords": [
         "Node-RED", "nodes", "iot", "ibm", "flow"


### PR DESCRIPTION
Added a snmp set node. My use case is a http API to SNMP for device control.

The code is a copy paste of other nodes, the main difference is in the oid format for snmp set following net-snmp lib (JSON Object):

[ { oid: ... , type:  ...,  value: .... } , { oid: ... , type:  ...,  value: .... } ] and has to be set in the message (msg.oids).

type is the integer form of net-snmp types.

