### PR TITLE
MYSQL Node: Override connection options

### DIFF
--- a/storage/mysql/68-mysql.html
+++ b/storage/mysql/68-mysql.html
@@ -65,7 +65,6 @@
     By its very nature it allows SQL injection... so <i>be careful out there...</i></p>
     <p><code>msg.topic</code> must hold the <i>query</i> for the database, and the result is returned in <code>msg.payload</code>.</p>
     <p><code>msg.payload</code> can contain an array of values to bind to the topic.</p>
-    <p><code>msg.mysqlpoolname</code> set this value to trigger mysql to change connections at runtime. It ignores the following settings otherwise.
     <p><code>msg.mysqlhost</code> can override the host using at the time message was received.
     <p><code>msg.mysqlport</code> can override the port using at the time message was received.
     <p><code>msg.mysqluser</code> can override the user using at the time message was received.

--- a/storage/mysql/68-mysql.html
+++ b/storage/mysql/68-mysql.html
@@ -65,6 +65,12 @@
     By its very nature it allows SQL injection... so <i>be careful out there...</i></p>
     <p><code>msg.topic</code> must hold the <i>query</i> for the database, and the result is returned in <code>msg.payload</code>.</p>
     <p><code>msg.payload</code> can contain an array of values to bind to the topic.</p>
+    <p><code>msg.mysqlpoolname</code> set this value to trigger mysql to change connections at runtime. It ignores the following settings otherwise.
+    <p><code>msg.mysqlhost</code> can override the host using at the time message was received.
+    <p><code>msg.mysqlport</code> can override the port using at the time message was received.
+    <p><code>msg.mysqluser</code> can override the user using at the time message was received.
+    <p><code>msg.mysqlpassword</code> can override the password using at the time message was received.
+    <p><code>msg.mysqldbname</code> can override the database name using at the time message was received.
     <p>Typically the returned payload will be an array of the result rows.</p>
     <p>If nothing is found for the key then <i>null</i> is returned,</p>
     <p>The reconnect timeout in milliseconds can be changed by adding a line to <b>settings.js</b>

--- a/storage/mysql/68-mysql.html
+++ b/storage/mysql/68-mysql.html
@@ -65,13 +65,11 @@
     By its very nature it allows SQL injection... so <i>be careful out there...</i></p>
     <p><code>msg.topic</code> must hold the <i>query</i> for the database, and the result is returned in <code>msg.payload</code>.</p>
     <p><code>msg.payload</code> can contain an array of values to bind to the topic.</p>
-    <p><code>msg.mysqlhost</code> can override the host using at the time message was received.
-    <p><code>msg.mysqlport</code> can override the port using at the time message was received.
-    <p><code>msg.mysqluser</code> can override the user using at the time message was received.
-    <p><code>msg.mysqlpassword</code> can override the password using at the time message was received.
-    <p><code>msg.mysqldbname</code> can override the database name using at the time message was received.
     <p>Typically the returned payload will be an array of the result rows.</p>
     <p>If nothing is found for the key then <i>null</i> is returned,</p>
+    <p><code>msg.mysqloptions</code> can override the connection options for mysql. See the official mysql module's documentation for example of options you can override.</p>
+    <p><code>msg.mysqloptions = { "host" :"127.0.0.1" };</code> would change only the host mysql connects to.</p>
+    <p>If any properties are overridden, then the connection pool is ended and reinitialized</p>
     <p>The reconnect timeout in milliseconds can be changed by adding a line to <b>settings.js</b>
     <pre>mysqlReconnectTime: 30000,</pre></p>
 </script>

--- a/storage/mysql/68-mysql.js
+++ b/storage/mysql/68-mysql.js
@@ -124,7 +124,7 @@ module.exports = function(RED) {
             /// Overide the connection pool options if they are passed in
             if(mysqloptions === undefined || mysqloptions == null) { return false; }
 
-            var node = this, haschange = fase;
+            var node = this, haschange = false;
             var originalOptions = JSON.stringify(node.mydbConfig.pooloptions);
             var updatedOpptions = JSON.stringify(mysqloptions);
             if(originalOptions !== updatedOpptions) {

--- a/storage/mysql/68-mysql.js
+++ b/storage/mysql/68-mysql.js
@@ -119,7 +119,6 @@ module.exports = function(RED) {
             node.on("input", function(msg) {
                 if (node.mydbConfig.connected) {
                     if (typeof msg.topic === 'string') {
-                        msg.incgmysql = true;
                         if((msg.mysqlpoolname !== undefined && node.mydbConfig.mysqlpoolname === undefined) || (msg.mysqlpoolname !== undefined && (msg.mysqlpoolname !== node.mydbConfig.mysqlpoolname))) {
                             /// Shutdown the existing pool because the msg wants us to connect somwhere else
                             if (node.mydbConfig.tick) { clearTimeout(node.mydbConfig.tick); }
@@ -127,7 +126,6 @@ module.exports = function(RED) {
                             node.mydbConfig.connected = false;
                             node.mydbConfig.emit("state"," ");
                             node.mydbConfig.pool.end(function (err) { 
-                                msg.mysqlmodifiedhost = true;
                                 node.mydbConfig.mysqlpoolname = msg.mysqlpoolname;
                                 if(msg.mysqlhost) {
                                     node.mydbConfig.host = msg.mysqlhost;

--- a/storage/mysql/68-mysql.js
+++ b/storage/mysql/68-mysql.js
@@ -17,6 +17,16 @@ module.exports = function(RED) {
         this.setMaxListeners(0);
         var node = this;
 
+        node.on("input", function (msg) {
+            if(msg.mysqlhost !== undefined) {
+                node.host = msg.mysqlhost;
+                node.port = msg.mysqlport;
+                node.credentials.user = msg.mysqluser;
+                node.credentials.password = msg.mysqlpassword;
+                node.dbname = msg.mysqldbname;
+            }
+        });
+        
         function checkVer() {
             node.connection.query("SELECT version();", [], function(err, rows) {
                 if (err) {

--- a/storage/mysql/68-mysql.js
+++ b/storage/mysql/68-mysql.js
@@ -119,29 +119,35 @@ module.exports = function(RED) {
             node.on("input", function(msg) {
                 if (node.mydbConfig.connected) {
                     if (typeof msg.topic === 'string') {
-                        if((msg.mysqlpoolname !== undefined && node.mydbConfig.mysqlpoolname === undefined) || (msg.mysqlpoolname !== undefined && (msg.mysqlpoolname !== node.mydbConfig.mysqlpoolname))) {
+                        var connectionChanged = false;
+                        if(msg.mysqlhost && node.mydbConfig.host !== msg.mysqlhost) {
+                            node.mydbConfig.host = msg.mysqlhost;
+                            connectionChanged = true;
+                        }
+                        if(msg.mysqlport && node.mydbConfig.port !== msg.mysqlport) {
+                            node.mydbConfig.port = msg.mysqlport;
+                            connectionChanged = true;
+                        }
+                        if(msg.mysqluser && node.mydbConfig.credentials.user !== msg.mysqluser) {
+                            node.mydbConfig.credentials.user = msg.mysqluser;
+                            connectionChanged = true;
+                        }
+                        if(msg.mysqlpassword && node.mydbConfig.credentials.password !== msg.mysqluser) {
+                            node.mydbConfig.credentials.password = msg.mysqlpassword;
+                            connectionChanged = true;
+                        }
+                        if(msg.mysqldbname && node.mydbConfig.dbname !== msg.mysqldbname) {
+                            node.mydbConfig.dbname = msg.mysqldbname;
+                            connectionChanged = true;
+                        }
+
+                        if(connectionChanged) {
                             /// Shutdown the existing pool because the msg wants us to connect somwhere else
                             if (node.mydbConfig.tick) { clearTimeout(node.mydbConfig.tick); }
                             if (node.mydbConfig.check) { clearInterval(node.mydbConfig.check); }
                             node.mydbConfig.connected = false;
                             node.mydbConfig.emit("state"," ");
                             node.mydbConfig.pool.end(function (err) { 
-                                node.mydbConfig.mysqlpoolname = msg.mysqlpoolname;
-                                if(msg.mysqlhost) {
-                                    node.mydbConfig.host = msg.mysqlhost;
-                                }
-                                if(msg.mysqlport) {
-                                    node.mydbConfig.port = msg.mysqlport;
-                                }
-                                if(msg.mysqluser) {
-                                    node.mydbConfig.credentials.user = msg.mysqluser;
-                                }
-                                if(msg.mysqlpassword) {
-                                    node.mydbConfig.credentials.password = msg.mysqlpassword;
-                                }
-                                if(msg.mysqldbname) {
-                                    node.mydbConfig.dbname = msg.mysqldbname;
-                                }
                                 node.mydbConfig.pool = null;
                                 node.mydbConfig.connect();
                                 node.mydbConfig.on("state", function(info) {


### PR DESCRIPTION
Allows the msg.mysqloptions to override the connection pool options.

Disconnect and reconnects if any connection options were overridden.

Useful for DevOps, and using function to set connection properties from environment variables.