### PR TITLE
fix deadbandEQ mode in rbe.js

### DIFF
--- a/function/rbe/rbe.js
+++ b/function/rbe/rbe.js
@@ -54,7 +54,7 @@ module.exports = function(RED) {
                             }
                         }
                         else if (Math.abs(n - node.previous[t]) > node.gap) {
-                            if (this.func === "deadband") {
+                            if (this.func === "deadband" || this.func === "deadbandEq") {
                                 if (node.inout === "out") { node.previous[t] = n; }
                                 node.send(msg);
                             }


### PR DESCRIPTION
In the drop down menu, the deadbandEq mode is defined as "block unless value change is greater or equal to". However, in the rbe.js, the msg is only sent when the value change is equal to the gap value in deadbandEq mode. 
 