### PR TITLE
Improve restart upon timeout (#338)

### DIFF
--- a/hardware/PiSrf/nrsrf.py
+++ b/hardware/PiSrf/nrsrf.py
@@ -29,14 +29,14 @@ def Measure():
         start = time.time()
         Dif = time.time() - realstart
         if Dif > 0.2:
-            print("Ultrasonic Sensor Timed out, Restarting.")
+            print("Ultrasonic Sensor Timed out (pre-echo), Restarting.")
             time.sleep(0.4)
             Main()
     while GPIO.input(ECHO)==1:
         stop = time.time()
         Dif = time.time() - realstart
         if Dif > 0.4:
-            print("Ultrasonic Sensor Timed out, Restarting.")
+            print("Ultrasonic Sensor Timed out (post-echo), Restarting.")
             time.sleep(0.2)
             Main()
 
@@ -60,8 +60,10 @@ if len(sys.argv) > 1:
 
     GPIO.setmode(GPIO.BOARD)        # Use GPIO BOARD numbers
     GPIO.setup(TRIGGER, GPIO.OUT)   # Trigger
+    GPIO.output(TRIGGER, False)     # DF
     GPIO.setup(ECHO, GPIO.OUT)      # Echo
     GPIO.output(ECHO, False)
+    time.sleep(0.1)		    # DF
     GPIO.setup(ECHO,GPIO.IN)
 
     # Flush stdin so we start clean
@@ -75,8 +77,9 @@ if len(sys.argv) > 1:
                 print(distance)
                 OLD = distance
             time.sleep(SLEEP)
-        except:                     # try to clean up on exit
-            print("0.0");
+        except Exception as e:		# try to clean up on exit
+            # print("0.0");
+            print(e)			# DF
             GPIO.cleanup(TRIGGER)
             GPIO.cleanup(ECHO)
             sys.exit(0)

--- a/hardware/PiSrf/nrsrf.py
+++ b/hardware/PiSrf/nrsrf.py
@@ -29,22 +29,25 @@ def Measure():
         start = time.time()
         Dif = time.time() - realstart
         if Dif > 0.2:
-            print("Ultrasonic Sensor Timed out (pre-echo), Restarting.")
+            print("Ultrasonic Sensor Timed out (pre-echo).")
             time.sleep(0.4)
-            Main()
+            restart()
     while GPIO.input(ECHO)==1:
         stop = time.time()
         Dif = time.time() - realstart
         if Dif > 0.4:
-            print("Ultrasonic Sensor Timed out (post-echo), Restarting.")
+            print("Ultrasonic Sensor Timed out (post-echo).")
             time.sleep(0.2)
-            Main()
+            restart()
 
     elapsed = stop-start
     distance = (elapsed * 36000)/2
 
     return distance
 
+def restart():
+    print("Restarting...")
+    os.execv(sys.executable, ['python'] + sys.argv)
 
 # Main program loop
 if len(sys.argv) > 1:
@@ -60,10 +63,10 @@ if len(sys.argv) > 1:
 
     GPIO.setmode(GPIO.BOARD)        # Use GPIO BOARD numbers
     GPIO.setup(TRIGGER, GPIO.OUT)   # Trigger
-    GPIO.output(TRIGGER, False)     # DF
+    GPIO.output(TRIGGER, False)     # Set low
     GPIO.setup(ECHO, GPIO.OUT)      # Echo
     GPIO.output(ECHO, False)
-    time.sleep(0.1)		    # DF
+    time.sleep(0.1)		    # Allow sensor to settle
     GPIO.setup(ECHO,GPIO.IN)
 
     # Flush stdin so we start clean
@@ -78,8 +81,7 @@ if len(sys.argv) > 1:
                 OLD = distance
             time.sleep(SLEEP)
         except Exception as e:		# try to clean up on exit
-            # print("0.0");
-            print(e)			# DF
+            print(e)			# Print error message on exception
             GPIO.cleanup(TRIGGER)
             GPIO.cleanup(ECHO)
             sys.exit(0)

--- a/hardware/PiSrf/nrsrf.py
+++ b/hardware/PiSrf/nrsrf.py
@@ -47,6 +47,8 @@ def Measure():
 
 def restart():
     print("Restarting...")
+    GPIO.cleanup(TRIGGER)
+    GPIO.cleanup(ECHO)
     os.execv(sys.executable, ['python'] + sys.argv)
 
 # Main program loop


### PR DESCRIPTION
This might still need some work; I'm very rarely getting a "local variable 'stop' referenced before assignment" exception, but can't see where it is occurring.

It's happening so infrequently I can't effectively troubleshoot. It doesn't seem to be when restart() is invoked (there is none of the associated print() output to the terminal). Any assistance appreciated.
