### PR TITLE
Fix typo in ledborg node

### DIFF
--- a/hardware/LEDborg/78-ledborg.html
+++ b/hardware/LEDborg/78-ledborg.html
@@ -4,7 +4,7 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
-    <div class="form-tips">Uses pins 11, 13 aand 15.<br/>
+    <div class="form-tips">Uses pins 11, 13 and 15.<br/>
     See info panel for the various input options and limitations.</div>
 </script>
 


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

I found typo, "aand" in node property UI of ledborg node. I changed "aand" to correct word, "and".

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality