### PR TITLE
Multiple NIC support for WeMo devices

### DIFF
--- a/hardware/wemo/lib/wemo.js
+++ b/hardware/wemo/lib/wemo.js
@@ -115,7 +115,7 @@ WeMoNG.prototype.start = function start() {
   //console.log("searching");
   var _wemo = this;
   _wemo.setMaxListeners(0);
-  _wemo._client = new Client();
+  _wemo._client = new Client({'explicitSocketBind': true});
   _wemo._client.setMaxListeners(0);
   _wemo._client.on('response', function (headers, statusCode, rinfo) {
     var location = url.parse(headers.LOCATION);

--- a/hardware/wemo/package.json
+++ b/hardware/wemo/package.json
@@ -19,7 +19,7 @@
   },
   "license": "APACHE-2.0",
   "dependencies": {
-    "node-ssdp": "~2.9.1",
+    "node-ssdp": "~3.2.5",
     "request": "~2.74.0",
     "xml2js": "~0.4.13",
     "util": "~0.10.3",

--- a/hardware/wemo/package.json
+++ b/hardware/wemo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-node-wemo",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Input and Output nodes for Belkin WeMo devices",
   "repository": "https://github.com/node-red/node-red-nodes/tree/master/hardware",
   "main": "WeMoNG.js",


### PR DESCRIPTION
Update version of node-ssdp and use `explicitSocketBind` option to work with multiple network interface cards. Based on discussion in [node-ssdp issue #34](https://github.com/diversario/node-ssdp/issues/34)
