### PR TITLE
Make exif node add exif data even if gps missing

### DIFF
--- a/utility/exif/94-exif.js
+++ b/utility/exif/94-exif.js
@@ -73,13 +73,17 @@ module.exports = function(RED) {
                                 node.log(error.toString());
                             }
                             else {
-                                //msg.payload remains the same buffer
-                                if ((exifData) && (exifData.hasOwnProperty("gps")) && (Object.keys(exifData.gps).length !== 0)) {
+                                if (exifData) {
                                     msg.exif = exifData;
-                                    addMsgLocationDataFromExifGPSData(msg);
+                                    if((exifData.hasOwnProperty("gps")) && (Object.keys(exifData.gps).length !== 0)) {
+                                        addMsgLocationDataFromExifGPSData(msg);
+                                    }
+                                    else {
+                                        node.log("The incoming image did not contain Exif GPS data.");
+                                    }
                                 }
                                 else {
-                                    node.warn("The incoming image did not contain Exif GPS data, nothing to do. ");
+                                    node.warn("The incoming image did not contain any Exif data, nothing to do. ");
                                 }
                             }
                             node.send(msg);


### PR DESCRIPTION
The exif node was not adding exif data to the msg.exif object unless the incoming image included gps coordinates.

This did not seem consistent with the documentation for the exif node and limits the use of the node to only images that have gps data.

The node now acts as per the node description:

>Extract Exif information from JPEG images.
This node expects an incoming JPEG image buffer. If Exif data is present, it extracts the data into the msg.exif object
The node then adds location data as msg.location, should the Exif data carry this information. msg.payload remains the original, unmodified image buffer.