### PR TITLE
Added pass through output to email send node

### DIFF
--- a/social/email/61-email.html
+++ b/social/email/61-email.html
@@ -69,6 +69,7 @@
     <p>Alternatively you may provide <code>msg.attachments</code> which should contain an array of one or
     more attachments in <a href="https://www.npmjs.com/package/nodemailer#attachments" target="_new">nodemailer</a> format.</p>
     <p>If required by your recipient you may also pass in a <code>msg.envelope</code> object, typically containing extra from and to properties.</p>
+    <p>The message is passed through to the output after the email has been sent. If an error is encountered then msg.error will be set to the error string. If no error then msg.error will not be present.</p>
     <p>Note: uses SMTP with SSL to port 465.</p>
 </script>
 
@@ -90,7 +91,7 @@
             global: { type:"boolean"}
         },
         inputs:1,
-        outputs:0,
+        outputs:1,
         icon: "envelope.png",
         align: "right",
         label: function() {

--- a/social/email/61-email.js
+++ b/social/email/61-email.js
@@ -108,10 +108,13 @@ module.exports = function(RED) {
                         if (error) {
                             node.error(error,msg);
                             node.status({fill:"red",shape:"ring",text:"email.status.sendfail"});
+                            msg.error = error;
                         } else {
                             node.log(RED._("email.status.messagesent",{response:info.response}));
                             node.status({});
+                            delete msg.error;
                         }
+                        node.send(msg);
                     });
                 }
                 else { node.warn(RED._("email.errors.nosmtptransport")); }

--- a/social/email/README.md
+++ b/social/email/README.md
@@ -57,4 +57,6 @@ The filename should be set using `msg.filename`. Optionally
 Alternatively you may provide `msg.attachments` which should contain an array of one or
 more attachments in <a href="https://www.npmjs.com/package/nodemailer#attachments" target="_new">nodemailer</a> format.
 
+The message is passed through to the output after the email has been sent. If an error is encountered then msg.error will be set to the error string. If no error then msg.error will not be present.
+
 Uses the *nodemailer* npm module.


### PR DESCRIPTION
This add a message pass-through output to the email send node.  This is useful for identifying which emails have been sent and which have not, this is difficult to achieve just using the status or catch nodes.  The Telegram send node uses the same technique.