### PR TITLE
Android as valid platform in 88-ping.js

### DIFF
--- a/io/ping/88-ping.js
+++ b/io/ping/88-ping.js
@@ -12,7 +12,7 @@ module.exports = function(RED) {
 
         node.tout = setInterval(function() {
             var ex;
-            if (plat == "linux") { ex = spawn('ping', ['-n', '-w', '5', '-c', '1', node.host]); }
+            if (plat == "linux" || plat == "android") { ex = spawn('ping', ['-n', '-w', '5', '-c', '1', node.host]); }
             else if (plat.match(/^win/)) { ex = spawn('ping', ['-n', '1', '-w', '5000', node.host]); }
             else if (plat == "darwin" || plat == "freebsd") { ex = spawn('ping', ['-n', '-t', '5', '-c', '1', node.host]); }
             else { node.error("Sorry - your platform - "+plat+" - is not recognised."); }


### PR DESCRIPTION
[https://termux.com/](url) uses the linux ping command, but the platform string is "android". Node Red crashes when the ping node is started on Termux. This patch provides a fix by adding "android" as a valid platform.