### PR TITLE
[ mongo documentation fixes]: fixing syntax

### DIFF
--- a/storage/mongodb/66-mongodb.html
+++ b/storage/mongodb/66-mongodb.html
@@ -90,20 +90,20 @@
     <p>Save will update an existing object or insert a new object if one does not already exist.</p>
     <p>Insert will insert a new object.</p>
     <p>Save and insert either store <code>msg</code> or <code>msg.payload</code>.</p>
-    <p>Update will modify an existing object or objects. The query to select objects to update uses <code>msg.query</code>
+    <p>Update will modify an existing object or objects. The query to select objects to update uses <code>msg.query</code>, 
     and the update to the element uses <code>msg.payload</code>. If <code>msg.query._id</code> is
     a valid mongo ObjectId string it will be converted to an ObjectId type.</p>
-    <p>Update can add a object if it does not exist or update multiple objects.</p>
+    <p>Update can add an object if it does not exist or update multiple objects.</p>
     <p>Remove will remove objects that match the query passed in on <code>msg.payload</code>. A blank query will delete
     <i>all of the objects</i> in the collection.</p>
     <p>You can either set the collection method in the node config or on <code>msg.collection</code>. Setting it in the
     node will override <code>msg.collection</code>.</p>
-    <p>By default MongoDB creates an <i>_id</i> property as the primary key - so repeated injections of the
+    <p>By default, MongoDB creates an <i>_id</i> property as the primary key, so repeated injections of the
     same <code>msg</code> will result in many database entries.</p>
-    <p>If this is NOT the desired behaviour - ie. you want repeated entries to overwrite, then you must set
+    <p>If this is NOT the desired behaviour, i.e., you want repeated entries to overwrite, then you must set
     the <code>msg._id</code> property to be a constant by the use of a previous function node.</p>
     <p>This could be a unique constant or you could create one based on some other msg property.</p>
-    <p>Currently we do not limit or cap the collection size at all... this may well change.</p>
+    <p>Currently we do not limit or cap the collection size, however this may well change.</p>
 </script>
 
 <script type="text/javascript">
@@ -187,9 +187,9 @@
 <script type="text/x-red" data-help-name="mongodb in">
     <p>Calls a MongoDB collection method based on the selected operator.</p>
     <p>Find queries a collection using the <code>msg.payload</code> as the query statement as per the .find() function.
-    Optionally, you may also (via a function) set a <code>msg.projection</code> object to constrain the returned
-    fields, a <code>msg.sort</code> object, a <code>msg.limit</code> number and a <code>msg.skip</code> number.</p>
-    <p>Count returns a count of the number of documents in a collection or matching a query using the
+    Optionally, you may also set a <code>msg.projection</code> object (via a function) to constrain the returned
+    fields. You can also set a <code>msg.sort</code> object, a <code>msg.limit</code> number and a <code>msg.skip</code> number.</p>
+    <p>Count returns a count of the number of documents in a collection, or matches a query using the
     <code>msg.payload</code> as the query statement.</p>
     <p>Aggregate provides access to the aggregation pipeline using the <code>msg.payload</code> as the pipeline array.</p>
     <p>You can either set the collection method in the node config or on <code>msg.collection</code>. Setting it in


### PR DESCRIPTION
Fixing many grammar errors in mongoDB documentation.
The fix has been reviewed by a professional technical writer .
