### PR TITLE
temporary solution for direct messages

### DIFF
--- a/social/twitter/27-twitter.js
+++ b/social/twitter/27-twitter.js
@@ -386,6 +386,7 @@ module.exports = function(RED) {
         this.twitterConfig = RED.nodes.getNode(this.twitter);
         var credentials = RED.nodes.getCredentials(this.twitter);
         var node = this;
+	var dm_user;
 
         if (credentials && credentials.screen_name == this.twitterConfig.screen_name) {
             var twit = new Ntwitter({
@@ -400,8 +401,7 @@ module.exports = function(RED) {
 
                     if (msg.payload.slice(0,2) == "D ") {
                             // direct message syntax: "D user message"
-                            var dm=true, dm_dst;
-                            [dm_dst,msg.payload]=msg.payload.match(/D\s+(\S+)\s+(.*)/).slice(1);
+                            [dm_user,msg.payload]=msg.payload.match(/D\s+(\S+)\s+(.*)/).slice(1);
                     }
                     if (msg.payload.length > 280) {
                         msg.payload = msg.payload.slice(0,279);
@@ -439,8 +439,8 @@ module.exports = function(RED) {
                     }
                     else {
                         if (typeof msg.params === 'undefined') { msg.params = {}; }
-                        if (dm) {
-                            twit.newDirectMessage(dm_dst,msg.payload, msg.params, function (err, data) {
+                        if (dm_user) {
+                            twit.newDirectMessage(dm_user,msg.payload, msg.params, function (err, data) {
                                 if (err) {
                                     node.status({fill:"red",shape:"ring",text:"twitter.status.failed"});
                                     node.error(err,msg);

--- a/social/twitter/27-twitter.js
+++ b/social/twitter/27-twitter.js
@@ -400,15 +400,14 @@ module.exports = function(RED) {
 
                     if (msg.payload.slice(0,2) == "D ") {
                             // split payload for legacy direct message support ("D user message")
-                            var dm=true;
-                            var dm_split=msg.payload.match(/D\s+(\S+)\s+(.*)/);
-                            var dm_dst=dm_split[1];
-                            msg.payload=dm_split[2];
+                            var dm=true, dm_dst;
+                            [dm_dst,msg.payload]=msg.payload.match(/D\s+(\S+)\s+(.*)/).slice(1);
                     }
                     if (msg.payload.length > 280) {
                         msg.payload = msg.payload.slice(0,279);
                         node.warn(RED._("twitter.errors.truncated"));
                     }
+
                     if (msg.media && Buffer.isBuffer(msg.media) || dm) {
                         var apiUrl = "https://api.twitter.com/1.1/statuses/update_with_media.json";
                         if (dm) {

--- a/social/twitter/27-twitter.js
+++ b/social/twitter/27-twitter.js
@@ -398,17 +398,16 @@ module.exports = function(RED) {
                 if (msg.hasOwnProperty("payload")) {
                     node.status({fill:"blue",shape:"dot",text:"twitter.status.tweeting"});
 
-                    if (msg.payload.length > 280) {
-                        msg.payload = msg.payload.slice(0,279);
-                        node.warn(RED._("twitter.errors.truncated"));
-                    }
-
                     if (msg.payload.slice(0,2) == "D ") {
                             // split payload for legacy direct message support ("D user message")
                             var dm=true;
                             var dm_split=msg.payload.match(/D\s+(\S+)\s+(.*)/);
                             var dm_dst=dm_split[1];
                             msg.payload=dm_split[2];
+                    }
+                    if (msg.payload.length > 280) {
+                        msg.payload = msg.payload.slice(0,279);
+                        node.warn(RED._("twitter.errors.truncated"));
                     }
                     if (msg.media && Buffer.isBuffer(msg.media) || dm) {
                         var apiUrl = "https://api.twitter.com/1.1/statuses/update_with_media.json";


### PR DESCRIPTION
Added a detection of the pattern "D < user > < message >" in order to use the specific function of the twitter-ng library to send direct messages (newDirectMessage).

Sadly it's only a temporary fix, since the API will be deprecated in June 19, 2018 (https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/guides/direct-message-migration)