### PR TITLE
Change DMA from 5 to 10

### DIFF
--- a/hardware/neopixel/neopix.py
+++ b/hardware/neopixel/neopix.py
@@ -13,7 +13,7 @@ except ImportError:
 LED_COUNT      = 8      # Number of LED pixels.
 LED_PIN        = 18      # GPIO pin connected to the pixels (must support PWM!).
 LED_FREQ_HZ    = 800000  # LED signal frequency in hertz (usually 800khz)
-LED_DMA        = 5       # DMA channel to use for generating signal (try 5)
+LED_DMA        = 10      # DMA channel to use for generating signal (try 10)
 LED_BRIGHTNESS = 255     # Set to 0 for darkest and 255 for brightest
 LED_INVERT     = False   # True to invert the signal (when using NPN transistor level shift)
 LED_CHANNEL    = 0       # PWM channel


### PR DESCRIPTION
I mentioned this a while ago.
Following changes to Pi firmware/kernel, the DMA channel 5 is not reliable for use anymore.  Other repositories have changed to use channel 10.  https://github.com/jgarff/rpi_ws281x/pull/266/commits

 I've been running 3 of my Pi on DMA 10 (1 new Pi3B+ and 2 older PiZeros running Jessie) for 2 months now without any issues so I'm making this pull request now

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


