### PR TITLE
Use words and URL in new Twitter portal

### DIFF
--- a/social/twitter/27-twitter.html
+++ b/social/twitter/27-twitter.html
@@ -5,7 +5,7 @@
         <i class="fa fa-at"></i> <input type="text" id="node-config-input-screen_name">
     </div>
     <div class="form-row">
-        <p style="margin-top: 30px;"><b>1.</b> <span data-i18n="twitter.label.create"></span> <a href="https://apps.twitter.com/" target="_blank" style="text-decoration:underline;">apps.twitter.com</a></p>
+        <p style="margin-top: 30px;"><b>1.</b> <span data-i18n="twitter.label.create"></span> <a href="https://developer.twitter.com/en/apps" target="_blank" style="text-decoration:underline;">developer.twitter.com/en/apps</a></p>
     </div>
     <div class="form-row">
         <p style="margin-top: 30px;"><b>2.</b> <span data-i18n="twitter.label.copy-consumer"></span></p>
@@ -128,10 +128,10 @@
         <dd>location information associated with the tweet, if known</dd>
     </dl>
     <h3>Details</h3>
-    <p>When searching for multiple terms, use a space for <i>and</i> and comma `,` for <i>or</i>.
+    <p>When searching for multiple terms, use a space for <i>and</i> and comma `,` for <i>or</i>.</p>
     <p>The full tweet object is documented <a href="https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/tweet-object" target="_new">here</a>.</p>
     <p><b>Note:</b> this node is subject to the rate limiting restrictions of the Twitter
-    API. It polls the API once a minute for updates. If you deploy frequently you may
+      API. It polls the API once a minute for updates. If you deploy frequently you may
       exceed the limit. The node will automatically delay polling until the end of the current
       rate limiting window.</p>
 </script>

--- a/social/twitter/locales/en-US/27-twitter.json
+++ b/social/twitter/locales/en-US/27-twitter.json
@@ -1,7 +1,7 @@
 {
     "twitter": {
         "label": {
-            "twitter-id":"Twitter ID",
+            "twitter-id": "Twitter ID",
             "search": "Search",
             "for": "for",
             "user": "User",
@@ -10,14 +10,13 @@
             "tweetslabel": "tweets",
             "eventslabel": "events",
             "create": "Create your own application at",
-            "copy-consumer": "From the 'Keys and Access Tokens' section, copy the Consumer Key and Secret",
-            "consumer_key": "Consumer Key",
-            "consumer_secret": "Consumer Secret",
-            "copy-accessToken": "Create a new 'Access Token' and copy the Access Token and Secret",
-            "access_key": "Access Token",
-            "access_secret": "Access Token Secret",
-            "enter-id":"Set your Twitter ID"
-
+            "copy-consumer": "From the 'Keys and tokens' section, copy the Consumer API keys",
+            "consumer_key": "API key",
+            "consumer_secret": "API secret key",
+            "copy-accessToken": "Create a new 'Access token & access token secret' and copy them",
+            "access_key": "Access token",
+            "access_secret": "Access token secret",
+            "enter-id": "Set your Twitter ID"
         },
         "placeholder": {
             "for": "comma-separated words, @ids, #tags",
@@ -34,22 +33,22 @@
         "status": {
             "using-geo": "Using geo location: __location__",
             "tweeting": "tweeting",
-            "failed":"failed"
+            "failed": "failed"
         },
         "warn": {
-            "nousers":"User option selected but no users specified",
-            "waiting":"Waiting for search term"
+            "nousers": "User option selected but no users specified",
+            "waiting": "Waiting for search term"
         },
         "errors": {
-            "ratelimit":"rate limit hit",
-            "limitrate":"limiting rate",
-            "streamerror":"stream error: __error__ (__rc__)",
-            "unexpectedend":"stream ended unexpectedly",
-            "invalidtag":"invalid tag property",
-            "missingcredentials":"missing twitter credentials",
-            "truncated":"truncated tweet greater than 280 characters",
-            "sendfail":"send tweet failed: __error__",
-            "nopayload":"no payload to tweet"
+            "ratelimit": "rate limit hit",
+            "limitrate": "limiting rate",
+            "streamerror": "stream error: __error__ (__rc__)",
+            "unexpectedend": "stream ended unexpectedly",
+            "invalidtag": "invalid tag property",
+            "missingcredentials": "missing twitter credentials",
+            "truncated": "truncated tweet greater than 280 characters",
+            "sendfail": "send tweet failed: __error__",
+            "nopayload": "no payload to tweet"
         }
     }
 }


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
When I was translating English messages into Japanese, I found that some words and URL are different from the new Twitter portal. Therefore, I modified these words and URL.

[Screen shot of new Twitter portal]
![twitterportal](https://user-images.githubusercontent.com/20310935/47284303-d627d680-d621-11e8-8a4c-eca4f6b3b00f.png)

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality