### PR TITLE
Issue with high stomp throughput

### DIFF
--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -66,15 +66,15 @@ module.exports = function(RED) {
         node.client.connect(function(sessionId) {
             node.log('subscribing to: '+node.topic);
             node.client.subscribe(node.topic, function(body, headers) {
+                var newmsg={"headers":headers,"topic":node.topic}
+                
                 try {
-                    msg.payload = JSON.parse(body);
+                    newmsg.payload = JSON.parse(body);
                 }
                 catch(e) {
-                    msg.payload = body;
+                    newmsg.payload = body;
                 }
-                msg.headers = headers;
-                msg.topic = node.topic;
-                node.send(msg);
+                node.send(newmsg);
             });
         }, function(error) {
             node.status({fill:"grey",shape:"dot",text:"error"});


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

The stomp connector seems to keep a pointer to the original message. The appropriate number of messages is triggered, but the payload is the same for some messages.
The bug does not appear under low stress.

It is not that difficult to reproduce with a workflow like this one.

[{"id":"81d9bd11.e33ef","type":"tab","label":"Flow 2"},{"id":"ca6c8775.05cce8","type":"inject","z":"81d9bd11.e33ef","name":"","topic":"","payload":"","payloadType":"date","repeat":"","crontab":"","once":false,"onceDelay":"","x":100,"y":60,"wires":[["a6cf35a9.50f498"]]},{"id":"d5bab34b.9798e","type":"stomp in","z":"81d9bd11.e33ef","name":"","server":"7ca6487d.8bd4b8","topic":"/queue/NAMA2","x":86.51986312866211,"y":307.23858547210693,"wires":[["2c42a4e7.81914c"]]},{"id":"d3cfafde.863f8","type":"stomp out","z":"81d9bd11.e33ef","name":"","server":"7ca6487d.8bd4b8","topic":"/queue/NAMA","x":559.5086059570312,"y":206.471586227417,"wires":[]},{"id":"8e9615d5.61a888","type":"debug","z":"81d9bd11.e33ef","name":"","active":true,"console":"false","complete":"false","x":438.51990509033203,"y":364.48859882354736,"wires":[]},{"id":"a6cf35a9.50f498","type":"function","z":"81d9bd11.e33ef","name":"","func":"msg.payload=[\"a\",\"b\",\"c\",\"d\",\"e\",\"f\",\"g\",\"h\",\"i\",\"j\"]\nreturn msg;","outputs":1,"noerr":0,"x":157.51420211791992,"y":147.74145889282227,"wires":[["86725ac9.632f08"]]},{"id":"86725ac9.632f08","type":"split","z":"81d9bd11.e33ef","name":"","splt":"\\n","x":314.51705169677734,"y":121.74146366119385,"wires":[["3e75a787.0f44f8"]]},{"id":"2c42a4e7.81914c","type":"function","z":"81d9bd11.e33ef","name":"","func":"msg.filename=\"/Users/snuids/Desktop/temp/file3\"+msg.payload+\".txt\"\nreturn msg;","outputs":1,"noerr":0,"x":117.2414779663086,"y":364.74142265319824,"wires":[["3f2ae58e.93bd7a"]]},{"id":"3f2ae58e.93bd7a","type":"file","z":"81d9bd11.e33ef","name":"","filename":"","appendNewline":true,"createDir":false,"overwriteFile":"true","x":255.24431991577148,"y":435.68745517730713,"wires":[["8e9615d5.61a888"]]},{"id":"3e75a787.0f44f8","type":"function","z":"81d9bd11.e33ef","name":"","func":"msg.payload+=msg.payload;\nreturn msg;","outputs":1,"noerr":0,"x":413.5142059326172,"y":168.9261245727539,"wires":[["d3cfafde.863f8"]]},{"id":"2be75fd8.6fc78","type":"stomp in","z":"81d9bd11.e33ef","name":"","server":"7ca6487d.8bd4b8","topic":"/queue/NAMA","x":83.01420593261719,"y":239.00567626953125,"wires":[["35261672.488d5a"]]},{"id":"1eb8c31c.b639cd","type":"stomp out","z":"81d9bd11.e33ef","name":"","server":"7ca6487d.8bd4b8","topic":"/queue/NAMA2","x":387.01422119140625,"y":300.00567626953125,"wires":[]},{"id":"35261672.488d5a","type":"msg-speed","z":"81d9bd11.e33ef","name":"","frequency":"min","estimation":false,"ignore":false,"x":258.5142059326172,"y":245.77271270751953,"wires":[[],["1eb8c31c.b639cd"]]},{"id":"7ca6487d.8bd4b8","type":"stomp-server","z":"","server":"app.nyx-ds.ovh","port":"61613","protocolversion":"1.0","vhost":"","reconnectretries":"0","reconnectdelay":"0.5","name":""}]

The problem is easier to reproduce when 1 message is split into multi messages such as done in the previous workflow.

It looks like there is a timing issue and the the msg reference is re-used before the end flow.

Basically my fix simply creates a new object which ensures that the reference to the message is unique and avoids random payload mix.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ x ] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
