### PR TITLE
add option to set criteria witch type of emails should be requested

### DIFF
--- a/social/email/61-email.html
+++ b/social/email/61-email.html
@@ -57,6 +57,7 @@
         <label for="node-input-dname"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
         <input type="text" id="node-input-dname" data-i18n="[placeholder]node-red:common.label.name">
     </div>
+
     <div class="form-tips" id="node-tip"><span data-i18n="[html]email.tip.cred"></span></div>
 </script>
 
@@ -171,6 +172,27 @@
             <option value="Delete" data-i18n="email.label.delete"></option>
         </select>
     </div>
+    <div class="form-row">
+        <label for="node-input-criteria"><i class="fa fa-criteria"></i> <span data-i18n="node-red:common.label.criteria"></span></label>
+        <select type="text" id="node-input-criteria">
+            <option value="ALL" selected="selected" data-i18n="email.label.all"></option>
+            <option value="ANSWERED" data-i18n="email.label.answered"></option>
+            <option value="FLAGGED" data-i18n="email.label.flagged"></option>
+            <option value="SEEN" selected="selected" data-i18n="email.label.seen"></option>
+            <option value="UNANSWERED" selected="selected" data-i18n="email.label.unanswered"></option>
+            <option value="UNFLAGGED" selected="selected" data-i18n="email.label.unflagged"></option>
+            <option value="UNSEEN" data-i18n="email.label.unseen"></option>
+            <!--
+            <option value="DELETED" data-i18n="email.label.delete"></option>
+            <option value="DRAFT" selected="selected" data-i18n="email.label.none"></option>
+            <option value="NEW" data-i18n="email.label.delete"></option>
+            <option value="UNDELETED" data-i18n="email.label.read"></option>
+            <option value="UNDRAFT" data-i18n="email.label.delete"></option>
+            <option value="RECENT" data-i18n="email.label.read"></option>
+            <option value="OLD" data-i18n="email.label.delete"></option>
+            -->
+        </select>
+    </div>
     <br/>
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
@@ -199,9 +221,11 @@
             if (protocol === "IMAP") {
                 $(".node-input-box").show();
                 $(".node-input-disposition").show();
+                $(".node-input-criteria").show();
             } else {
                 $(".node-input-box").hide();
                 $(".node-input-disposition").hide();
+                $(".node-input-criteria").hide();
             }
             checkPorts();
         });
@@ -252,6 +276,7 @@
             port: {value:"993",required:true},
             box: {value:"INBOX"}, // For IMAP, The mailbox to process
             disposition: { value: "Read" }, // For IMAP, the disposition of the read email
+	        criteria: {value: "UNSEEN"},
             repeat: {value:"300",required:true},
             fetch: {value:"auto"},
             inputs: {value:0}

--- a/social/email/61-email.js
+++ b/social/email/61-email.js
@@ -160,6 +160,7 @@ module.exports = function(RED) {
         this.useSSL= n.useSSL;
         this.protocol = n.protocol || "IMAP";
         this.disposition = n.disposition || "None"; // "None", "Delete", "Read"
+        this.criteria = n.criteria || "UNSEEN"; // "ALL", "ANSWERED", "FLAGGED", "SEEN", "UNANSWERED", "UNFLAGGED", "UNSEEN"
 
         var flag = false;
 
@@ -343,7 +344,7 @@ module.exports = function(RED) {
                         return;
                     }
                     else {
-                        imap.search([ 'UNSEEN' ], function(err, results) {
+                        imap.search([ this.criteria ], function(err, results) {
                             if (err) {
                                 node.status({fill:"red", shape:"ring", text:"email.status.foldererror"});
                                 node.error(RED._("email.errors.fetchfail", {folder:node.box}),err);

--- a/social/email/locales/en-US/61-email.json
+++ b/social/email/locales/en-US/61-email.json
@@ -20,7 +20,15 @@
             "disposition": "Disposition",
             "none": "None",
             "read": "Mark Read",
-            "delete": "Delete"
+            "delete": "Delete",
+            "criteria": "Criteria",
+            "all": "All",
+            "answered": "Answered",
+            "flagged": "Flagged",
+            "seen": "Seen",
+            "unanswered": "Unanswered",
+            "unflagged": "Unflagged",
+            "unseen": "Unseen"
         },
         "default-message": "__description__\n\nFile from Node-RED is attached: __filename__",
         "tip": {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
In the old version of "email in" node only unseen version are requested. With this changes, a user could select what type of criteria he/she want to set (all, seen, answered, flagged, unanswered, unflagged, unseen).
[Get seen messages, forum request](https://discourse.nodered.org/t/how-to-get-seen-messages-in-email-module/7623)
<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
