### PR TITLE
add to email threading headers

### DIFF
--- a/social/email/61-email.html
+++ b/social/email/61-email.html
@@ -65,7 +65,7 @@
     <p>Sends the <code>msg.payload</code> as an email, with a subject of <code>msg.topic</code>.</p>
     <p>The default message recipient can be configured in the node, if it is left
     blank it should be set using the <code>msg.to</code> property of the incoming message. If left blank
-    you can also specify <code>msg.cc</code> and/or <code>msg.bcc</code> properties.</p>
+ you can also specify any or all of: <code>msg.cc</code>, <code>msg.bcc</code>, <code>msg.replyTo</code>, <code>msg.inReplyTo</code>, <code>msg.references</code> properties.</p>
     <p>You may optionally set <code>msg.from</code> in the payload which will override the <code>userid</code>
     default value.</p>
     <p>The payload can be html format.</p>

--- a/social/email/61-email.js
+++ b/social/email/61-email.js
@@ -87,6 +87,9 @@ module.exports = function(RED) {
                     if (node.name === "") {
                         sendopts.cc = msg.cc;
                         sendopts.bcc = msg.bcc;
+                        sendopts.inReplyTo = msg.inReplyTo;
+                        sendopts.replyTo = msg.replyTo;
+                        sendopts.references = msg.references;
                     }
                     sendopts.subject = msg.topic || msg.title || "Message from Node-RED"; // subject line
                     if (msg.hasOwnProperty("envelope")) { sendopts.envelope = msg.envelope; }

--- a/social/email/locales/ja/61-email.html
+++ b/social/email/locales/ja/61-email.html
@@ -2,7 +2,7 @@
 
 <script type="text/x-red" data-help-name="e-mail">
     <p><code>msg.payload</code>をemailとして送信します。件名は<code>msg.topic</code>で指定します。</p>
-    <p>メッセージの受信者のデフォルトはノードに設定できます。空のままとした場合は、入力メッセージの<code>msg.to</code>を設定します。<code>msg.cc</code>や<code>msg.bcc</code>プロパティを設定することもできます。</p>
+    <p>メッセージの受信者のデフォルトはノードに設定できます。空のままとした場合は、入力メッセージの<code>msg.to</code>を設定します。<code>msg.cc</code>や<code>msg.bcc</code>や<code>msg.replyTo</code>や<code>msg.inReplyTo</code>や<code>msg.references</code>プロパティを設定することもできます。</p>
     <p><code>msg.from</code>を指定すると、<code>ユーザID</code>のデフォルト値を上書きできます。</p>
     <p>ペイロードはHTML形式とすることも可能です。</p>
     <p>ペイロードにバイナリバッファを指定すると、添付ファイルに変換します。ファイル名は<code>msg.filename</code>に指定、メッセージ本体は<code>msg.description</code>に指定することができます。</p>


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes
Discussed in: https://discourse.nodered.org/t/use-reply-headers-for-email-threading/11364

> Currently it is possible to have e-mails as inputs or outputs of flows.
> 
> Some headers can be set directly, like `To` and `CC`, but not all: specifically, `In-Reply-To` and `References` should be updated for email threading to work as expected.
> 
> This would allow for flows where an email by Node-RED can be clearly marked as a reply to the email that initially triggered the flow.
> 
> An easy way of implementing this is to add those fields to the existing `nodemailer` interface, as it implements them already.

Add email threading headers that nodemailer already supports:
- msg.replyTo
- msg.inReplyTo
- msg.references

and update documentation in available locales

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
