### PR TITLE
use latest mailparser API

### DIFF
--- a/social/email/package.json
+++ b/social/email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-node-email",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Node-RED nodes to send and receive simple emails",
   "dependencies": {
     "imap": "^0.8.19",


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

The API diverged between the original mailparser and mailparser-mit, which causes the email node to silently fail to emit any of the fetched emails.

This pull request uses the latest mailparser API.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
