### PR TITLE
email optionally uses criteria from message

### DIFF
--- a/social/email/61-email.html
+++ b/social/email/61-email.html
@@ -182,6 +182,7 @@
             <option value="UNANSWERED" data-i18n="email.label.unanswered"></option>
             <option value="UNFLAGGED" data-i18n="email.label.unflagged"></option>
             <option value="UNSEEN" selected="selected" data-i18n="email.label.unseen"></option>
+            <option value="_msg_" data-i18n="email.label.criteriaFromMsg"></option>
             <!--
             <option value="DELETED" data-i18n="email.label.delete"></option>
             <option value="DRAFT" data-i18n="email.label.none"></option>

--- a/social/email/61-email.js
+++ b/social/email/61-email.js
@@ -353,7 +353,7 @@ module.exports = function(RED) {
                     }
                     else {
                         var criteria = ((node.criteria === '_msg_')?
-                                        (msg.criteria || []):
+                                        (msg.criteria || ["UNSEEN"]):
                                         ([node.criteria]));
                         imap.search(criteria, function(err, results) {
                             if (err) {

--- a/social/email/61-email.js
+++ b/social/email/61-email.js
@@ -352,7 +352,10 @@ module.exports = function(RED) {
                         return;
                     }
                     else {
-                        imap.search([ node.criteria ], function(err, results) {
+                        var criteria = ((node.criteria === '_msg_')?
+                                        (msg.criteria || []):
+                                        ([node.criteria]));
+                        imap.search(criteria, function(err, results) {
                             if (err) {
                                 node.status({fill:"red", shape:"ring", text:"email.status.foldererror"});
                                 node.error(RED._("email.errors.fetchfail", {folder:node.box}),err);

--- a/social/email/locales/en-US/61-email.json
+++ b/social/email/locales/en-US/61-email.json
@@ -22,6 +22,7 @@
             "read": "Mark Read",
             "delete": "Delete",
             "criteria": "Criteria",
+            "criteriaFromMsg": "- set from msg.criteria -",
             "all": "All",
             "answered": "Answered",
             "flagged": "Flagged",

--- a/social/email/locales/ja/61-email.json
+++ b/social/email/locales/ja/61-email.json
@@ -15,7 +15,8 @@
             "disposition": "受信後の処理",
             "none": "なし",
             "read": "既読",
-            "delete": "削除"
+            "delete": "削除",
+            "criteriaFromMsg": "- msg.criteriaから使用 -"
         },
         "default-message": "__description__\n\nNode-REDからファイルが添付されました: __filename__",
         "tip": {

--- a/social/email/package.json
+++ b/social/email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-node-email",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Node-RED nodes to send and receive simple emails",
   "dependencies": {
     "imap": "^0.8.19",


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Optionally use `msg.criteria` to set the IMAP criteria.
This allows for generation of detailed queries through flows when triggering an email
fetch in IMAP.

Detailed criteria is available at the underlying library's README:
https://github.com/mscdex/node-imap

A simple example in a function node to fetch a specific message again, even though it might already be "Seen":
```javascript
criteria = [['HEADER', 'message-id', msg.header['message-id']]]
msg = {}
msg['criteria'] = criteria
```
This coupled with a fetch and a different disposition allows a selective deleting of emails after some processing.

Discussion:
https://discourse.nodered.org/t/provide-search-criteria-to-imap-on-email-node-on-trigger/11642

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
