### PR TITLE
Tail node add input filename

### DIFF
--- a/storage/tail/28-tail.html
+++ b/storage/tail/28-tail.html
@@ -47,7 +47,8 @@
             name: {value:""},
             filetype: {value:"text"},
             split: {value:"[\\r]{0,1}\\n"},
-            filename: {value:""}
+            filename: {value:""},
+            inputs: {value:1}
         },
         color:"BurlyWood",
         inputs:1,
@@ -64,6 +65,14 @@
                 if (this.value === "text") { $("#node-tail-split").show(); }
                 else { $("#node-tail-split").hide(); }
             });
-        }
+        },
+        oneditsave: function() {
+            var that = this;
+            if($("#node-input-filename").val()===""){
+                that.inputs = 1;
+            } else {
+               that.inputs = 0;
+           }
+       }
     });
 </script>

--- a/storage/tail/28-tail.html
+++ b/storage/tail/28-tail.html
@@ -31,7 +31,7 @@
     <dl class="message-properties">
         <dt class="optional">filename <span class="property-type">string</span></dt>
         <dd>If not configured in the node, this optional property sets the name of the file to be tailed.
-        If an empty string <code>""</code> is reviced, the tailing will stop.</dd>
+        If an empty string <code>""</code> is received, the tailing will stop.</dd>
     </dl>
     <h3>Outputs</h3>
     <ul>

--- a/storage/tail/28-tail.html
+++ b/storage/tail/28-tail.html
@@ -27,6 +27,12 @@
 <script type="text/x-red" data-help-name="tail">
     <p>Tails (watches for things to be added) to the configured file.</p>
     <p>Note: On Windows you may need to close the file between writes for any updates to be registered.</p>
+    <h3>Input</h3>
+    <dl class="message-properties">
+        <dt class="optional">filename <span class="property-type">string</span></dt>
+        <dd>If not configured in the node, this optional property sets the name of the file to be tailed.
+        If an empty string <code>""</code> is reviced, the tailing will stop.</dd>
+    </dl>
     <h3>Outputs</h3>
     <ul>
         <li>Text (UTF-8) files will be returned as strings.</li>
@@ -41,10 +47,10 @@
             name: {value:""},
             filetype: {value:"text"},
             split: {value:"[\\r]{0,1}\\n"},
-            filename: {value:"",required:true}
+            filename: {value:""}
         },
         color:"BurlyWood",
-        inputs:0,
+        inputs:1,
         outputs:1,
         icon: "file.png",
         label: function() {

--- a/storage/tail/28-tail.js
+++ b/storage/tail/28-tail.js
@@ -37,7 +37,7 @@ module.exports = function(RED) {
                 });
 
                 node.tail.on("error", function(err) {
-                    node.status({ fill: "red",shape:"ring", text: "error" });
+                    node.status({ fill: "red",shape:"ring", text: "node-red:common.status.error" });
                     node.error(err.toString());
                 });
             }
@@ -51,17 +51,17 @@ module.exports = function(RED) {
             node.status({});
             fileTail();
         } else {
-            node.status({ fill: "grey", text: "paused" });
+            node.status({ fill: "grey", text: "tail.state.stopped" });
             node.on('input', function (msg) {
                 if (!msg.hasOwnProperty("filename")) {
-                    node.error("Missing filename on input");
+                    node.error(RED._("tail.state.nofilename"));
                 }else if (msg.filename === node.filename) {
-                    node.warn("No change of filename input");
+                    node.warn(RED._("tail.state.nofilechange"));
                 } else if (msg.filename === "") {
                     node.filename = "";
                     if (node.tail) { node.tail.unwatch(); }
                     if (node.tout) { clearTimeout(node.tout); }
-                    node.status({ fill: "grey", text: "paused" });
+                    node.status({ fill: "grey", text: "tail.state.stopped" });
                 } else {
                     node.filename = msg.filename;
                     if (node.tail) { node.tail.unwatch(); }

--- a/storage/tail/locales/en-US/28-tail.json
+++ b/storage/tail/locales/en-US/28-tail.json
@@ -15,6 +15,11 @@
         "errors": {
             "windowsnotsupport": "Not currently supported on Windows.",
             "filenotfound": "File not found"
+        },
+        "state":{
+            "stopped": "stopped",
+            "nofilename":"Missing filename on input",
+            "nofilechange":"No change of filename input"
         }
     }
 }


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Added filename parameter as an input, to allow for dynamically change the files being monitored. 
I needed it, and now others can use it too.
Is backwards compatible with existing flows.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality