### PR TITLE
Close only the number of objects that was created

### DIFF
--- a/hardware/mcp3008/pimcp3008.js
+++ b/hardware/mcp3008/pimcp3008.js
@@ -58,12 +58,24 @@ module.exports = function(RED) {
         catch(err) {
             node.error("Error : Can't find SPI device - is SPI enabled in raspi-config ?");
         }
-
+        
         node.on("close", function(done) {
             if (mcp3xxx.length !== 0) {
                 var j=0;
-                for (var i=0; i<8; i++) {
-                    mcp3xxx[i].close(function() { j += 1; if (j === 8) {done()} });
+                for (var i=0; i<chans; i++) {
+                    try {
+                        mcp3xxx[i].close(function(err) {
+                            if (err) {
+                                node.error("Error: "+err);
+                            }
+                            j += 1;
+                            if (j === chans) {
+                                done();
+                            }
+                        });
+                    } catch (err) {
+                        node.error("Error: " + err.message);
+                    }
                 }
                 mcp3xxx = [];
             }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
This pull request addresses issue #567.

The close event of the node does not loop through the mcp3xxx array further than the amount of channels that was defined.
I have also added a try catch block to catch and log exceptions thrown by the close() method of the mcp-spi-adc object.
<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
