### PR TITLE
Move English help to en-US directory

### DIFF
--- a/analysis/sentiment/72-sentiment.html
+++ b/analysis/sentiment/72-sentiment.html
@@ -9,27 +9,6 @@
     </div>
 </script>
 
-<script type="text/x-red" data-help-name="sentiment">
-    <p>Analyses the chosen property, default <code>payload</code>, and adds a <code>sentiment</code> object.</p>
-    <h3>Outputs</h3>
-    <dl class="message-properties">
-        <dt>sentiment <span class="property-type">object</span></dt>
-        <dd>contains the resulting AFINN-111 sentiment.</dd>
-        <dt>sentiment.score <span class="property-type">number</span></dt>
-        <dd>the sentiment score.</dd>
-    </dl>
-    <h3>Inputs</h3>
-    <dl class="message-properties">
-        <dt>overrides <span class="property-type">object</span></dt>
-        <dd>an object of word score overrides can be supplied - <code>{ word:score,... }</code>.</dd>
-    </dl>
-    <h3>Details</h3>
-    <p>A score greater than zero is positive and less than zero is negative.</p>
-    <p>The score typically ranges from -5 to +5, but can go higher and lower.</p>
-    <p>See <a href="https://github.com/thisandagain/sentiment/blob/master/README.md" target="_blank">the Sentiment docs here.</a>.</p>
-    <p><b>Note</b>: There is also a multi-language version available - <b>node-red-node-multilang-sentiment</b></p>
-</script>
-
 <script type="text/javascript">
     RED.nodes.registerType('sentiment',{
         category: 'analysis-function',

--- a/analysis/sentiment/locales/en-US/72-sentiment.html
+++ b/analysis/sentiment/locales/en-US/72-sentiment.html
@@ -1,0 +1,20 @@
+<script type="text/x-red" data-help-name="sentiment">
+    <p>Analyses the chosen property, default <code>payload</code>, and adds a <code>sentiment</code> object.</p>
+    <h3>Outputs</h3>
+    <dl class="message-properties">
+        <dt>sentiment <span class="property-type">object</span></dt>
+        <dd>contains the resulting AFINN-111 sentiment.</dd>
+        <dt>sentiment.score <span class="property-type">number</span></dt>
+        <dd>the sentiment score.</dd>
+    </dl>
+    <h3>Inputs</h3>
+    <dl class="message-properties">
+        <dt>overrides <span class="property-type">object</span></dt>
+        <dd>an object of word score overrides can be supplied - <code>{ word:score,... }</code>.</dd>
+    </dl>
+    <h3>Details</h3>
+    <p>A score greater than zero is positive and less than zero is negative.</p>
+    <p>The score typically ranges from -5 to +5, but can go higher and lower.</p>
+    <p>See <a href="https://github.com/thisandagain/sentiment/blob/master/README.md" target="_blank">the Sentiment docs here.</a>.</p>
+    <p><b>Note</b>: There is also a multi-language version available - <b>node-red-node-multilang-sentiment</b></p>
+</script>

--- a/function/rbe/locales/en-US/rbe.html
+++ b/function/rbe/locales/en-US/rbe.html
@@ -1,0 +1,37 @@
+<script type="text/x-red" data-help-name="rbe">
+    <p>Report by Exception node - only passes on data if the payload has changed.</p>
+    <p>It can also block until the value changes by a specified amount - deadband modes.</p>
+    <h3>Inputs</h3>
+    <dl class="message-properties">
+        <dt>payload
+            <span class="property-type">number | string | (object)</span>
+        </dt>
+        <dd>RBE mode will accept numbers, strings, and simple objects. Other modes must provide a parseable number.</dd>
+        <dt class="optional">topic <span class="property-type">string</span>
+        </dt>
+        <dd>if specified the function will work on a per topic basis.</dd>
+        <dt class="optional">reset<span class="property-type">any</span></dt>
+        <dd>if set clears the stored value for the specified msg.topic, or
+        all topics if msg.topic is not specified.</dd>
+    </dl>
+    <h3>Outputs</h3>
+    <dl class="message-properties">
+        <dt>payload
+            <span class="property-type">as per input</span>
+        </dt>
+        <dd>If triggered the output will be the same as the input.</dd>
+    </dl>
+    <h3>Details</h3>
+    <p>In RBE mode this node will block until the <code>msg.payload</code> is
+    different to the previous one. </p>
+    <p>In Deadband modes the incoming payload must contain a parseable number and is
+    output only if greater than + or - the band gap away from a previous value.</p>
+    <p>Deadband also supports % - only sends if the input differs by more than x% of the original value.</p>
+    <p>In Narrowband mode the incoming payload is blocked if it is more than + or - the band gap
+    away from the previous value. Useful for ignoring outliers from a faulty sensor for example.</p>
+    <p>Both Deadband and Narrowband allow comparison against either the previous valid output value, thus
+    ignoring any values out of range; or the previous input value, which resets the set point, thus allowing
+    gradual drift (deadband), or a step change (narrowband).</p>
+    <p><b>Note:</b> This works on a per <code>msg.topic</code> basis. This means that a single rbe node can
+    handle multiple different topics at the same time.</p>
+</script>

--- a/function/rbe/rbe.html
+++ b/function/rbe/rbe.html
@@ -33,44 +33,6 @@
     </div>
 </script>
 
-<script type="text/x-red" data-help-name="rbe">
-    <p>Report by Exception node - only passes on data if the payload has changed.</p>
-    <p>It can also block until the value changes by a specified amount - deadband modes.</p>
-    <h3>Inputs</h3>
-    <dl class="message-properties">
-        <dt>payload
-            <span class="property-type">number | string | (object)</span>
-        </dt>
-        <dd>RBE mode will accept numbers, strings, and simple objects. Other modes must provide a parseable number.</dd>
-        <dt class="optional">topic <span class="property-type">string</span>
-        </dt>
-        <dd>if specified the function will work on a per topic basis.</dd>
-        <dt class="optional">reset<span class="property-type">any</span></dt>
-        <dd>if set clears the stored value for the specified msg.topic, or
-        all topics if msg.topic is not specified.</dd>
-    </dl>
-    <h3>Outputs</h3>
-    <dl class="message-properties">
-        <dt>payload
-            <span class="property-type">as per input</span>
-        </dt>
-        <dd>If triggered the output will be the same as the input.</dd>
-    </dl>
-    <h3>Details</h3>
-    <p>In RBE mode this node will block until the <code>msg.payload</code> is
-    different to the previous one. </p>
-    <p>In Deadband modes the incoming payload must contain a parseable number and is
-    output only if greater than + or - the band gap away from a previous value.</p>
-    <p>Deadband also supports % - only sends if the input differs by more than x% of the original value.</p>
-    <p>In Narrowband mode the incoming payload is blocked if it is more than + or - the band gap
-    away from the previous value. Useful for ignoring outliers from a faulty sensor for example.</p>
-    <p>Both Deadband and Narrowband allow comparison against either the previous valid output value, thus
-    ignoring any values out of range; or the previous input value, which resets the set point, thus allowing
-    gradual drift (deadband), or a step change (narrowband).</p>
-    <p><b>Note:</b> This works on a per <code>msg.topic</code> basis. This means that a single rbe node can
-    handle multiple different topics at the same time.</p>
-</script>
-
 <script type="text/javascript">
     RED.nodes.registerType("rbe", {
         color:"#E2D96E",

--- a/social/email/61-email.html
+++ b/social/email/61-email.html
@@ -1,4 +1,3 @@
-
 <script type="text/x-red" data-template-name="e-mail">
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-envelope"></i> <span data-i18n="email.label.to"></span></label>
@@ -59,27 +58,6 @@
     </div>
 
     <div class="form-tips" id="node-tip"><span data-i18n="[html]email.tip.cred"></span></div>
-</script>
-
-<script type="text/x-red" data-help-name="e-mail">
-    <p>Sends the <code>msg.payload</code> as an email, with a subject of <code>msg.topic</code>.</p>
-    <p>The default message recipient can be configured in the node, if it is left
-    blank it should be set using the <code>msg.to</code> property of the incoming message. If left blank
- you can also specify any or all of: <code>msg.cc</code>, <code>msg.bcc</code>, <code>msg.replyTo</code>, <code>msg.inReplyTo</code>, <code>msg.references</code> properties.</p>
-    <p>You may optionally set <code>msg.from</code> in the payload which will override the <code>userid</code>
-    default value.</p>
-    <h3>GMail users</h3>
-    <p>If you are accessing GMail you may need to either enable <a target="_new" href="https://support.google.com/mail/answer/185833?hl=en">an application password</a>,
-    or enable <a target="_new" href="https://support.google.com/accounts/answer/6010255?hl=en">less secure access</a> via your Google account settings.</p>
-    <h3>Details</h3>
-    <p>The payload can be html format.</p>
-    <p>If the payload is a binary buffer then it will be converted to an attachment.
-    The filename should be set using <code>msg.filename</code>. Optionally <code>msg.description</code> can be added for the body text.</p>
-    <p>Alternatively you may provide <code>msg.attachments</code> which should contain an array of one or
-    more attachments in <a href="https://nodemailer.com/message/attachments/" target="_new">nodemailer</a> format.</p>
-    <p>If required by your recipient you may also pass in a <code>msg.envelope</code> object, typically containing extra from and to properties.</p>
-    <p>If you have own signed certificates, Nodemailer can complain about that and refuse sending the message. In this case you can try switching off TLS.</p>
-    <p>Note: uses SMTP with SSL to port 465.</p>
 </script>
 
 <script type="text/javascript">
@@ -235,38 +213,6 @@
             checkPorts();
         });
     </script>
-</script>
-
-<script type="text/x-red" data-help-name="e-mail in">
-    <p>Repeatedly gets emails from an IMAP server and forwards on as a msg if not already seen.</p>
-    <p>The subject is loaded into <code>msg.topic</code> and <code>msg.payload</code> is the plain text body.
-       If there is text/html then that is returned in <code>msg.html</code>. <code>msg.from</code> and <code>msg.date</code> are also set if you need them.</p>
-    <p>Additionally <code>msg.header</code> contains the complete header object including
-    <i>to</i>, <i>cc</i> and other potentially useful properties.</p>
-    <p>It can optionally mark the message as Read (default), Delete it, or leave unmarked (None).</p>
-    <p>Uses the imap module.</p>
-    <p><b>Note:</b> this node <i>only</i> gets the most recent single email from the inbox, so set the repeat (polling) time appropriately.</p>
-    <p>Note: uses IMAP with SSL to port 993.</p>
-    <p>Any attachments supplied in the incoming email can be found in the <code>msg.attachments</code> property. This will be an array of objects where
-    each object represents a specific attachments.  The format of the object is:</p>
-
-<pre>
-{
-  contentType:        // The MIME content description
-  fileName:           // A suggested file name associated with this attachment
-  transferEncoding:   // How was the original email attachment encodded?
-  contentDisposition: // Unknown
-  generatedFileName:  // A suggested file name associated with this attachment
-  contentId:          // A unique generated ID for this attachment
-  checksum:           // A checksum against the data
-  length:             // Size of data in bytes
-  content:            // The actual content of the data contained in a Node.js Buffer object
-                      // We can turn this into a base64 data string with content.toString('base64')
-}
-</pre>
-<p>For POP3, the default port numbers are 110 for plain TCP and 995 for SSL.  For IMAP the port numbers are 143 for plain TCP and 993 for SSL.</p>
-<p>The maximum refresh interval is 2147483 seconds (24.8 days).</p>
-
 </script>
 
 <script type="text/javascript">

--- a/social/email/locales/en-US/61-email.html
+++ b/social/email/locales/en-US/61-email.html
@@ -1,0 +1,53 @@
+<script type="text/x-red" data-help-name="e-mail">
+    <p>Sends the <code>msg.payload</code> as an email, with a subject of <code>msg.topic</code>.</p>
+    <p>The default message recipient can be configured in the node, if it is left
+    blank it should be set using the <code>msg.to</code> property of the incoming message. If left blank
+ you can also specify any or all of: <code>msg.cc</code>, <code>msg.bcc</code>, <code>msg.replyTo</code>, <code>msg.inReplyTo</code>, <code>msg.references</code> properties.</p>
+    <p>You may optionally set <code>msg.from</code> in the payload which will override the <code>userid</code>
+    default value.</p>
+    <h3>GMail users</h3>
+    <p>If you are accessing GMail you may need to either enable <a target="_new" href="https://support.google.com/mail/answer/185833?hl=en">an application password</a>,
+    or enable <a target="_new" href="https://support.google.com/accounts/answer/6010255?hl=en">less secure access</a> via your Google account settings.</p>
+    <h3>Details</h3>
+    <p>The payload can be html format.</p>
+    <p>If the payload is a binary buffer then it will be converted to an attachment.
+    The filename should be set using <code>msg.filename</code>. Optionally <code>msg.description</code> can be added for the body text.</p>
+    <p>Alternatively you may provide <code>msg.attachments</code> which should contain an array of one or
+    more attachments in <a href="https://nodemailer.com/message/attachments/" target="_new">nodemailer</a> format.</p>
+    <p>If required by your recipient you may also pass in a <code>msg.envelope</code> object, typically containing extra from and to properties.</p>
+    <p>If you have own signed certificates, Nodemailer can complain about that and refuse sending the message. In this case you can try switching off TLS.</p>
+    <p>Note: uses SMTP with SSL to port 465.</p>
+</script>
+
+<script type="text/x-red" data-help-name="e-mail in">
+    <p>Repeatedly gets emails from an IMAP server and forwards on as a msg if not already seen.</p>
+    <p>The subject is loaded into <code>msg.topic</code> and <code>msg.payload</code> is the plain text body.
+       If there is text/html then that is returned in <code>msg.html</code>. <code>msg.from</code> and <code>msg.date</code> are also set if you need them.</p>
+    <p>Additionally <code>msg.header</code> contains the complete header object including
+    <i>to</i>, <i>cc</i> and other potentially useful properties.</p>
+    <p>It can optionally mark the message as Read (default), Delete it, or leave unmarked (None).</p>
+    <p>Uses the imap module.</p>
+    <p><b>Note:</b> this node <i>only</i> gets the most recent single email from the inbox, so set the repeat (polling) time appropriately.</p>
+    <p>Note: uses IMAP with SSL to port 993.</p>
+    <p>Any attachments supplied in the incoming email can be found in the <code>msg.attachments</code> property. This will be an array of objects where
+    each object represents a specific attachments.  The format of the object is:</p>
+
+<pre>
+{
+  contentType:        // The MIME content description
+  fileName:           // A suggested file name associated with this attachment
+  transferEncoding:   // How was the original email attachment encodded?
+  contentDisposition: // Unknown
+  generatedFileName:  // A suggested file name associated with this attachment
+  contentId:          // A unique generated ID for this attachment
+  checksum:           // A checksum against the data
+  length:             // Size of data in bytes
+  content:            // The actual content of the data contained in a Node.js Buffer object
+                      // We can turn this into a base64 data string with content.toString('base64')
+}
+</pre>
+<p>For POP3, the default port numbers are 110 for plain TCP and 995 for SSL.  For IMAP the port numbers are 143 for plain TCP and 993 for SSL.</p>
+<p>The maximum refresh interval is 2147483 seconds (24.8 days).</p>
+
+</script>
+

--- a/social/feedparser/32-feedparse.html
+++ b/social/feedparser/32-feedparse.html
@@ -1,4 +1,3 @@
-
 <script type="text/x-red" data-template-name="feedparse">
     <div class="form-row">
         <label for="node-input-url"><i class="fa fa-globe"></i> <span data-i18n="feedparse.label.feedurl"></span></label>
@@ -12,14 +11,6 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
         <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
     </div>
-</script>
-
-<script type="text/x-red" data-help-name="feedparse">
-    <p>Monitors an RSS/atom feed for new entries.</p>
-    <p>The <code>msg.topic</code> contains the original article link. The <code>msg.payload</code>
-    contains the description, and <code>msg.article</code> contains the complete article object,
-    which has properties such as <code>.title</code>, <code>.summary</code>, <code>.date</code> and so on.</p>
-    <p>The Refresh interval cannot be greater than 35790 minutes (approx 24.8 days).
 </script>
 
 <script type="text/javascript">

--- a/social/feedparser/locales/en-US/32-feedparse.html
+++ b/social/feedparser/locales/en-US/32-feedparse.html
@@ -1,0 +1,7 @@
+<script type="text/x-red" data-help-name="feedparse">
+    <p>Monitors an RSS/atom feed for new entries.</p>
+    <p>The <code>msg.topic</code> contains the original article link. The <code>msg.payload</code>
+    contains the description, and <code>msg.article</code> contains the complete article object,
+    which has properties such as <code>.title</code>, <code>.summary</code>, <code>.date</code> and so on.</p>
+    <p>The Refresh interval cannot be greater than 35790 minutes (approx 24.8 days).
+</script>

--- a/social/twitter/27-twitter.html
+++ b/social/twitter/27-twitter.html
@@ -1,4 +1,3 @@
-
 <script type="text/x-red" data-template-name="twitter-credentials">
     <div class="form-row">
         <label for="node-config-input-screen_name"><i class="fa fa-twitter"></i> <span data-i18n="twitter.label.twitter-id"></span></label>
@@ -31,15 +30,6 @@
         <input type="password" id="node-config-input-access_token_secret">
     </div>
 </script>
-
-<script type="text/x-red" data-help-name="twitter-credentials">
-    <p>Authentication for the Twitter API</p>
-    <p>Earlier versions of this node provided one-click authentication. Twitter removed the ability
-       to do that in June 2018. You must now register your own application with
-       <a href="https://developer.twitter.com/">Twitter</a> and generate your own access tokens.</p>
-
-</script>
-
 
 <script type="text/javascript">
 (function() {
@@ -107,33 +97,6 @@
         <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
     </div>
     <div class="form-tips"><span data-i18n="[html]twitter.tip"></span></div>
-</script>
-
-<script type="text/x-red" data-help-name="twitter in">
-    <p>Twitter input node. Can be used to search either:
-    <ul><li>the public stream for tweets containing the configured search term</li>
-        <li>tweets from accounts that the authenticated user follows</li>
-        <li>tweets by specified users</li>
-        <li>direct messages received by the authenticated user</li>
-    </ul></p>
-    <h3>Outputs</h3>
-    <dl class="message-properties">
-        <dt>payload <span class="property-type">string</span></dt>
-        <dd>the text of the tweet</dd>
-        <dt>topic <span class="property-type">string</span></dt>
-        <dd>set to <code>tweets/<i>screen_name</i></code></dd>
-        <dt>tweet <span class="property-type">object</span></dt>
-        <dd>the full tweet object returned by the Twitter API</dd>
-        <dt>location <span class="property-type">object</span></dt>
-        <dd>location information associated with the tweet, if known</dd>
-    </dl>
-    <h3>Details</h3>
-    <p>When searching for multiple terms, use a space for <i>and</i> and comma `,` for <i>or</i>.</p>
-    <p>The full tweet object is documented <a href="https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/tweet-object" target="_new">here</a>.</p>
-    <p><b>Note:</b> this node is subject to the rate limiting restrictions of the Twitter
-      API. It polls the API once a minute for updates. If you deploy frequently you may
-      exceed the limit. The node will automatically delay polling until the end of the current
-      rate limiting window.</p>
 </script>
 
 <script type="text/javascript">
@@ -204,7 +167,6 @@
     });
 </script>
 
-
 <script type="text/x-red" data-template-name="twitter out">
     <div class="form-row">
         <label for="node-input-twitter"><i class="fa fa-user"></i> <span data-i18n="twitter.label.twitter-id"></span></label>
@@ -214,27 +176,6 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
         <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
     </div>
-</script>
-
-<script type="text/x-red" data-help-name="twitter out">
-    <p>Send tweets and direct messages.</p>
-    <h3>Inputs</h3>
-    <dl class="message-properties">
-        <dt>payload <span class="property-type">string</span></dt>
-        <dd>Sent as the body of the tweet. See below for how to send a Direct Message</dd>
-        <dt class="optional">media <span class="property-type">buffer</span></dt>
-        <dd>A Buffer of an image to attach to the tweet</dd>
-        <dt class="optional">params <span class="property-type">object</span></dt>
-        <dd>Additional parameters to pass to the Twitter status update API.</dd>
-    </dl>
-    <h3>Details</h3>
-    <p>This nodes sends a tweet for the authenticated user. If <code>msg.media</code>
-    is set and contains a Buffer, it is attached as an image.</p>
-    <p>To send a Direct Message, the payload should be formatted as: <code>D {username} {message}</code>.</p>
-    <p>Note that you cannot attach an image to a direct message.</p>
-    <p>If <code>msg.params</code> exists and is an object of name:value pairs, they
-       will be included in the request to the Twitter api. The available values are documented
-       <a href="https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-statuses-update#parameters" target="_new">here</a>.</p>
 </script>
 
 <script type="text/javascript">

--- a/social/twitter/locales/en-US/27-twitter.html
+++ b/social/twitter/locales/en-US/27-twitter.html
@@ -1,0 +1,55 @@
+<script type="text/x-red" data-help-name="twitter-credentials">
+    <p>Authentication for the Twitter API</p>
+    <p>Earlier versions of this node provided one-click authentication. Twitter removed the ability
+       to do that in June 2018. You must now register your own application with
+       <a href="https://developer.twitter.com/">Twitter</a> and generate your own access tokens.</p>
+
+</script>
+
+<script type="text/x-red" data-help-name="twitter in">
+    <p>Twitter input node. Can be used to search either:
+    <ul><li>the public stream for tweets containing the configured search term</li>
+        <li>tweets from accounts that the authenticated user follows</li>
+        <li>tweets by specified users</li>
+        <li>direct messages received by the authenticated user</li>
+    </ul></p>
+    <h3>Outputs</h3>
+    <dl class="message-properties">
+        <dt>payload <span class="property-type">string</span></dt>
+        <dd>the text of the tweet</dd>
+        <dt>topic <span class="property-type">string</span></dt>
+        <dd>set to <code>tweets/<i>screen_name</i></code></dd>
+        <dt>tweet <span class="property-type">object</span></dt>
+        <dd>the full tweet object returned by the Twitter API</dd>
+        <dt>location <span class="property-type">object</span></dt>
+        <dd>location information associated with the tweet, if known</dd>
+    </dl>
+    <h3>Details</h3>
+    <p>When searching for multiple terms, use a space for <i>and</i> and comma `,` for <i>or</i>.</p>
+    <p>The full tweet object is documented <a href="https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/tweet-object" target="_new">here</a>.</p>
+    <p><b>Note:</b> this node is subject to the rate limiting restrictions of the Twitter
+      API. It polls the API once a minute for updates. If you deploy frequently you may
+      exceed the limit. The node will automatically delay polling until the end of the current
+      rate limiting window.</p>
+</script>
+
+<script type="text/x-red" data-help-name="twitter out">
+    <p>Send tweets and direct messages.</p>
+    <h3>Inputs</h3>
+    <dl class="message-properties">
+        <dt>payload <span class="property-type">string</span></dt>
+        <dd>Sent as the body of the tweet. See below for how to send a Direct Message</dd>
+        <dt class="optional">media <span class="property-type">buffer</span></dt>
+        <dd>A Buffer of an image to attach to the tweet</dd>
+        <dt class="optional">params <span class="property-type">object</span></dt>
+        <dd>Additional parameters to pass to the Twitter status update API.</dd>
+    </dl>
+    <h3>Details</h3>
+    <p>This nodes sends a tweet for the authenticated user. If <code>msg.media</code>
+    is set and contains a Buffer, it is attached as an image.</p>
+    <p>To send a Direct Message, the payload should be formatted as: <code>D {username} {message}</code>.</p>
+    <p>Note that you cannot attach an image to a direct message.</p>
+    <p>If <code>msg.params</code> exists and is an object of name:value pairs, they
+       will be included in the request to the Twitter api. The available values are documented
+       <a href="https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-statuses-update#parameters" target="_new">here</a>.</p>
+</script>

--- a/storage/tail/28-tail.html
+++ b/storage/tail/28-tail.html
@@ -1,4 +1,3 @@
-
 <script type="text/x-red" data-template-name="tail">
     <div class="form-row">
          <label for="node-input-filename"><i class="fa fa-file"></i> <span data-i18n="tail.label.filename"></span></label>
@@ -22,22 +21,6 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="tail.label.name"></span></label>
         <input type="text" id="node-input-name" data-i18n="[placeholder]tail.label.name">
     </div>
-</script>
-
-<script type="text/x-red" data-help-name="tail">
-    <p>Tails (watches for things to be added) to the configured file.</p>
-    <p>Note: On Windows you may need to close the file between writes for any updates to be registered.</p>
-    <h3>Input</h3>
-    <dl class="message-properties">
-        <dt class="optional">filename <span class="property-type">string</span></dt>
-        <dd>If not configured in the node, this optional property sets the name of the file to be tailed.
-        If an empty string <code>""</code> is received, the tailing will stop.</dd>
-    </dl>
-    <h3>Outputs</h3>
-    <ul>
-        <li>Text (UTF-8) files will be returned as strings.</li>
-        <li>Binary files will be returned as Buffer objects.</li>
-    </ul>
 </script>
 
 <script type="text/javascript">

--- a/storage/tail/locales/en-US/28-tail.html
+++ b/storage/tail/locales/en-US/28-tail.html
@@ -1,0 +1,15 @@
+<script type="text/x-red" data-help-name="tail">
+    <p>Tails (watches for things to be added) to the configured file.</p>
+    <p>Note: On Windows you may need to close the file between writes for any updates to be registered.</p>
+    <h3>Input</h3>
+    <dl class="message-properties">
+        <dt class="optional">filename <span class="property-type">string</span></dt>
+        <dd>If not configured in the node, this optional property sets the name of the file to be tailed.
+        If an empty string <code>""</code> is received, the tailing will stop.</dd>
+    </dl>
+    <h3>Outputs</h3>
+    <ul>
+        <li>Text (UTF-8) files will be returned as strings.</li>
+        <li>Binary files will be returned as Buffer objects.</li>
+    </ul>
+</script>


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Based on [the document about internationalization](https://nodered.org/docs/creating-nodes/i18n), I moved English help text to `en-US` directory.
 
## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality