### PR TITLE
Fix sqlite repo link.

### DIFF
--- a/storage/sqlite/package.json
+++ b/storage/sqlite/package.json
@@ -7,7 +7,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://https://github.com/node-red/node-red-nodes/tree/master/storage/sqlite"
+        "url": "https://github.com/node-red/node-red-nodes/tree/master/storage/sqlite"
     },
     "license": "Apache-2.0",
     "keywords": [


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Commit below didn't fix repo link completely.  
(Added duplicate ``https://``)

https://github.com/node-red/node-red-nodes/commit/8547f26a45a5e23bc0d9065557b008e9cf702629#diff-e2b7398a0535cb762907027f07f974a3

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
