### PR TITLE
[ja] Support i18n 28-tail node.

### DIFF
--- a/storage/tail/locales/ja/28-tail.json
+++ b/storage/tail/locales/ja/28-tail.json
@@ -13,7 +13,12 @@
             "binary": "バイナリバッファ"
         },
         "errors": {
-            "windowsnotsupport": "現在Windows上での動作は対応していません"
+            "windowsnotsupport": "現在Windows上での動作は対応していません",
+            "filenotfound": "ファイルが見つかりませんでした"
+        },
+        "state":{
+            "stopped": "停止",
+            "nofilename":"ファイル名の指定がありません"
         }
     }
 }


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

- Add Japanese translation to 28-tail node.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
