### PR TITLE
Unify file name for binary attachment in e-mail node

### DIFF
--- a/social/email/61-email.js
+++ b/social/email/61-email.js
@@ -103,7 +103,7 @@ module.exports = function(RED) {
                             if ((msg.payload[0] === 0x89)&&(msg.payload[1] === 0x50)) { fe = "png"; } //4E
                             msg.filename = "attachment."+fe;
                         }
-                        var fname = msg.filename.replace(/^.*[\\\/]/, '') || "file.bin";
+                        var fname = msg.filename.replace(/^.*[\\\/]/, '') || "attachment.bin";
                         sendopts.attachments = [ { content:msg.payload, filename:fname } ];
                         if (msg.hasOwnProperty("headers") && msg.headers.hasOwnProperty("content-type")) {
                             sendopts.attachments[0].contentType = msg.headers["content-type"];


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Currently, the e-mail node uses both "file.bin" and "attachment.bin" for binary attachment file when the file name is not specified. It is a little confused for e-mail receivers of the binary files. To unify the file name, I changed the "file.bin" to "attachment.bin".

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
