### PR TITLE
Add and remove namespaces for i18n

### DIFF
--- a/hardware/PiGpio/36-rpi-gpio.html
+++ b/hardware/PiGpio/36-rpi-gpio.html
@@ -173,8 +173,8 @@
         <label for="node-input-read" style="width:70%;"><span data-i18n="rpi-gpio.label.readinitial"></span></label>
     </div>
     <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
-        <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
     </div>
     <div class="form-tips" id="pin-tip"><span data-i18n="[html]rpi-gpio.tip.pin"></span></div>
     <div class="form-tips"><span data-i18n="[html]rpi-gpio.tip.in"></span></div>
@@ -366,8 +366,8 @@
         <input type="text" id="node-input-freq" placeholder="100"> Hz
     </div>
     <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
-        <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
     </div>
     <div class="form-tips" id="pin-tip"><span data-i18n="[html]rpi-gpio.tip.pin"></span></div>
     <div class="form-tips" id="dig-tip"><span data-i18n="[html]rpi-gpio.tip.dig"></span></div>
@@ -497,8 +497,8 @@
     </div>
     <br/>
     <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
-        <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
     </div>
 </script>
 
@@ -528,8 +528,8 @@
 
 <script type="text/html" data-template-name="rpi-keyboard">
     <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
-        <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
     </div>
 </script>
 

--- a/hardware/PiGpio/36-rpi-gpio.js
+++ b/hardware/PiGpio/36-rpi-gpio.js
@@ -87,7 +87,7 @@ module.exports = function(RED) {
             }
         }
         else {
-            node.status({fill:"grey",shape:"dot",text:"node-red:rpi-gpio.status.not-available"});
+            node.status({fill:"grey",shape:"dot",text:"rpi-gpio.status.not-available"});
             if (node.read === true) {
                 var val;
                 if (node.intype == "up") { val = 1; }
@@ -193,7 +193,7 @@ module.exports = function(RED) {
             }
         }
         else {
-            node.status({fill:"grey",shape:"dot",text:"node-red:rpi-gpio.status.not-available"});
+            node.status({fill:"grey",shape:"dot",text:"rpi-gpio.status.not-available"});
             node.on("input", function(msg) {
                 node.status({fill:"grey",shape:"dot",text:RED._("rpi-gpio.status.na",{value:msg.payload.toString()})});
             });
@@ -260,7 +260,7 @@ module.exports = function(RED) {
             });
         }
         else {
-            node.status({fill:"grey",shape:"dot",text:"node-red:rpi-gpio.status.not-available"});
+            node.status({fill:"grey",shape:"dot",text:"rpi-gpio.status.not-available"});
         }
     }
     RED.nodes.registerType("rpi-mouse",PiMouseNode);
@@ -313,7 +313,7 @@ module.exports = function(RED) {
             });
         }
         else {
-            node.status({fill:"grey",shape:"dot",text:"node-red:rpi-gpio.status.not-available"});
+            node.status({fill:"grey",shape:"dot",text:"rpi-gpio.status.not-available"});
         }
     }
     RED.nodes.registerType("rpi-keyboard",PiKeyboardNode);


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
While using the latest Raspberry Pi image (Version: February 2020), I found that there are missing and unnecessary namespaces in Raspberry Pi nodes. Therefore, I added and removed them.

![image](https://user-images.githubusercontent.com/20310935/74026918-89b90380-49ea-11ea-9b9d-20ace4453533.png)

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality