### PR TITLE
Update Japanese message catalogue of RPI-GPIO

### DIFF
--- a/hardware/PiGpio/locales/ja/36-rpi-gpio.json
+++ b/hardware/PiGpio/locales/ja/36-rpi-gpio.json
@@ -1,73 +1,75 @@
-"rpi-gpio": {
-    "label": {
-        "gpiopin": "GPIO",
-        "selectpin": "端子の選択",
-        "resistor": "抵抗",
-        "readinitial": "デプロイや再起動時に端子の初期状態を読み込む",
-        "type": "出力形式",
-        "initpin": "端子の状態を初期化",
-        "debounce": "デバウンス",
-        "freq": "頻度",
-        "button": "ボタン",
-        "pimouse": "Pi Mouse",
-        "pikeyboard": "Pi Keyboard",
-        "left": "Left",
-        "right": "Right",
-        "middle": "Middle"
-    },
-    "resistor": {
-        "none": "なし",
-        "pullup": "プルアップ",
-        "pulldown": "プルダウン"
-    },
-    "digout": "デジタル出力",
-    "pwmout": "PWM出力",
-    "servo": "サーボ出力",
-    "initpin0": "端子の初期レベル - Low (0)",
-    "initpin1": "端子の初期レベル - High (1)",
-    "left": "左",
-    "right": "右",
-    "middle": "中間",
-    "any": "全て",
-    "pinname": "端子",
-    "alreadyuse": "使用中",
-    "alreadyset": "設定済",
-    "tip": {
-        "pin": "<b>使用中の端子</b>: ",
-        "in": "注釈: 入力値は、0または1の数値のみ対応しています。",
-        "dig": "注釈: 「出力形式」として「デジタル出力」を用いる場合、入力値は0または1の数値である必要があります。",
-        "pwm": "注釈: 「出力形式」として「PWM出力」を用いる場合、入力値は0～100の数値である必要があります。",
-        "ser": "<b>注釈</b>: サーボ出力向け - 入力値は0～100の間である必要があります。50が中心値です。"
-    },
-    "types": {
+{
+    "rpi-gpio": {
+        "label": {
+            "gpiopin": "GPIO",
+            "selectpin": "端子の選択",
+            "resistor": "抵抗",
+            "readinitial": "デプロイや再起動時に端子の初期状態を読み込む",
+            "type": "出力形式",
+            "initpin": "端子の状態を初期化",
+            "debounce": "デバウンス",
+            "freq": "頻度",
+            "button": "ボタン",
+            "pimouse": "Pi Mouse",
+            "pikeyboard": "Pi Keyboard",
+            "left": "Left",
+            "right": "Right",
+            "middle": "Middle"
+        },
+        "resistor": {
+            "none": "なし",
+            "pullup": "プルアップ",
+            "pulldown": "プルダウン"
+        },
         "digout": "デジタル出力",
-        "input": "入力",
-        "pullup": "プルアップの入力",
-        "pulldown": "プルダウンの入力",
         "pwmout": "PWM出力",
-        "servo": "サーボ出力"
-    },
-    "status": {
-        "stopped": "停止",
-        "closed": "切断",
-        "not-running": "停止中",
-        "not-available": "利用不可",
-        "na": "N/A : __value__",
-        "ok": "OK"
-    },
-    "errors": {
-        "ignorenode": "Raspberry Pi固有のノードを無視しました",
-        "version": "バージョンコマンドが失敗しました",
-        "sawpitype": "Saw Pi Type",
-        "libnotfound": "RPi.GPIO pythonライブラリを見つけられませんでした",
-        "alreadyset": "GPIO端子  __pin__ は既に出力形式が設定されています: __type__",
-        "invalidpin": "GPIO端子が不正です",
-        "invalidinput": "入力が不正です",
-        "needtobeexecutable": "__command__ は実行可能である必要があります",
-        "mustbeexecutable": "nrgpio は実行可能である必要があります",
-        "commandnotfound": "nrgpio コマンドが見つかりません",
-        "commandnotexecutable": "nrgpio コマンドが実行可能ではありません",
-        "error": "エラー: __error__",
-        "pythoncommandnotfound": "nrgpio python コマンドが実行されていません"
+        "servo": "サーボ出力",
+        "initpin0": "端子の初期レベル - Low (0)",
+        "initpin1": "端子の初期レベル - High (1)",
+        "left": "左",
+        "right": "右",
+        "middle": "中間",
+        "any": "全て",
+        "pinname": "端子",
+        "alreadyuse": "使用中",
+        "alreadyset": "設定済",
+        "tip": {
+            "pin": "<b>使用中の端子</b>: ",
+            "in": "注釈: 入力値は、0または1の数値のみ対応しています。",
+            "dig": "注釈: 「出力形式」として「デジタル出力」を用いる場合、入力値は0または1の数値である必要があります。",
+            "pwm": "注釈: 「出力形式」として「PWM出力」を用いる場合、入力値は0～100の数値である必要があります。",
+            "ser": "<b>注釈</b>: サーボ出力向け - 入力値は0～100の間である必要があります。50が中心値です。"
+        },
+        "types": {
+            "digout": "デジタル出力",
+            "input": "入力",
+            "pullup": "プルアップの入力",
+            "pulldown": "プルダウンの入力",
+            "pwmout": "PWM出力",
+            "servo": "サーボ出力"
+        },
+        "status": {
+            "stopped": "停止",
+            "closed": "切断",
+            "not-running": "停止中",
+            "not-available": "利用不可",
+            "na": "N/A : __value__",
+            "ok": "OK"
+        },
+        "errors": {
+            "ignorenode": "Raspberry Pi固有のノードを無視しました",
+            "version": "バージョンコマンドが失敗しました",
+            "sawpitype": "Saw Pi Type",
+            "libnotfound": "RPi.GPIO pythonライブラリを見つけられませんでした",
+            "alreadyset": "GPIO端子  __pin__ は既に出力形式が設定されています: __type__",
+            "invalidpin": "GPIO端子が不正です",
+            "invalidinput": "入力が不正です",
+            "needtobeexecutable": "__command__ は実行可能である必要があります",
+            "mustbeexecutable": "nrgpio は実行可能である必要があります",
+            "commandnotfound": "nrgpio コマンドが見つかりません",
+            "commandnotexecutable": "nrgpio コマンドが実行可能ではありません",
+            "error": "エラー: __error__",
+            "pythoncommandnotfound": "nrgpio python コマンドが実行されていません"
+        }
     }
 }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Japanese message catalogue of RPI-GPIO node lacks enclosing braces.
This PR fixes this problem.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
