### PR TITLE
Add support of new style message handler to gpio out node

### DIFF
--- a/hardware/PiGpio/36-rpi-gpio.js
+++ b/hardware/PiGpio/36-rpi-gpio.js
@@ -129,7 +129,7 @@ module.exports = function(RED) {
             }
         }
 
-        function inputlistener(msg) {
+        function inputlistener(msg, send, done) {
             if (msg.payload === "true") { msg.payload = true; }
             if (msg.payload === "false") { msg.payload = false; }
             var out = Number(msg.payload);
@@ -138,7 +138,11 @@ module.exports = function(RED) {
             if ((out >= 0) && (out <= limit)) {
                 if (RED.settings.verbose) { node.log("out: "+out); }
                 if (node.child !== null) {
-                    node.child.stdin.write(out+"\n");
+                    node.child.stdin.write(out+"\n", () => {
+                        if (done) {
+                            done();
+                        }
+                    });
                     node.status({fill:"green",shape:"dot",text:msg.payload.toString()});
                 }
                 else {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
In some cases, it is necessary to wait for the GPIO output processing to be completed before taking the next action.
Since the GPIO out node has no output port, new style message handler (with `done` callback) needs to be supported to make this possible.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
