### PR TITLE
On error sending pushover message throw a catchable exception

### DIFF
--- a/social/pushover/57-pushover.js
+++ b/social/pushover/57-pushover.js
@@ -91,16 +91,16 @@ module.exports = function(RED) {
                     node.error("[57-pushover.js] Error: attachment property must be a path to a local file or a Buffer containing an image");
                     return;
                 }
-                pushMessage(pushmsg);
+                pushMessage(pushmsg,msg);
             }
             else {
                 node.warn("Pushover credentials not set.");
             }
         });
 
-        function pushMessage(pushmsg) {
+        function pushMessage(pushmsg,msg) {
             pusher.send( pushmsg, function(err, response) {
-                if (err) { node.error(err,pushmsg); }
+                if (err) { node.error(err,msg); }
                 else {
                     try {
                         response = JSON.parse(response);

--- a/social/pushover/57-pushover.js
+++ b/social/pushover/57-pushover.js
@@ -100,7 +100,7 @@ module.exports = function(RED) {
 
         function pushMessage(pushmsg) {
             pusher.send( pushmsg, function(err, response) {
-                if (err) { node.error(err); }
+                if (err) { node.error(err,pushmsg); }
                 else {
                     try {
                         response = JSON.parse(response);


### PR DESCRIPTION
Throws an catchable exception if there is any error in sending the message. So you can react to it with a catch node

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
If there is any error with sending a pushover message you can now react to it with a catch node and send it for example as an email. I'm using Pushover via curl and bash for some time now and sometimes there's an error submitting the messages to pushover. I then get an email as backup. So this change enables it in Node-RED to react when there is an error sending the message. 

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ x ] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
