### PR TITLE
Enable the use of environment variables to define GPIO pin number

### DIFF
--- a/hardware/PiGpio/36-rpi-gpio.html
+++ b/hardware/PiGpio/36-rpi-gpio.html
@@ -70,9 +70,7 @@
 <script type="text/html" data-template-name="rpi-gpio in">
 
     <div class="form-row" style="min-width: 540px">
-        <label>&nbsp;&nbsp;&nbsp;&nbsp;<span data-i18n="rpi-gpio.pinname"></span></label>
-        <input type="text" id="node-input-pin">
-        <div><p></p><div><label></label>
+		<label><i class="fa fa-circle"></i> <span data-i18n="rpi-gpio.pinname"></span></label>
         <div class="rpi-gpio-pinTable">
             <div class="pinTableBody" id="pinform">
                 <div class="pinTableRow">
@@ -158,7 +156,10 @@
             </div>
         </div>
     </div>
-    <div><p></p><div><label></label>
+    <div class="form-row">
+        <label>&nbsp;&nbsp;&nbsp;&nbsp;</label>
+        <input type="text" id="node-input-pin" style="width: 352px">
+    </div>
     <div class="form-row">
         <label for="node-input-intype"><i class="fa fa-level-up"></i> <span data-i18n="rpi-gpio.label.resistor"></span></label>
         <select type="text" id="node-input-intype" style="width:100px;">
@@ -189,20 +190,23 @@
         "5":"29", "6":"31", "12":"32", "13":"33", "19":"35", "16":"36", "26":"37", "20":"38", "21":"40"
     };
     var pinsInUse = {};
+    var validPinValues = Object.values(bcm2pin);
     var isEnvVar = function (value) {
-        var re = /^\s*\${\s*([0-9a-zA-Z_]+)\s*}\s*/;
+        var re = /^\${([0-9a-zA-Z_]+)}$/;
         var match = value.match(re);
-        if (match) {
-            return "${" + match[1] + "}";
-        }
-        return "";
+        return Boolean(match);
     };
     var isInt = function (value) {
         return parseInt(value).toString() === value.trim();
+    };
+    var uncheckAll = function() {
+        for (var i=0; i< validPinValues.length; i++) {
+            $("#pinform input[value="+validPinValues[i]+"]").prop('checked', false);
+        }
     }
     var validatePin = function (value) {
-        return isEnvVar(value) || isInt(value);
-    }
+        return isEnvVar(value) || (isInt(value) && validPinValues.includes(value));
+    };
     RED.nodes.registerType('rpi-gpio in',{
         category: 'Raspberry Pi',
         color:"#c6dbef",
@@ -243,16 +247,20 @@
                 pinsInUse = data || {};
                 $('#pin-tip').html(pintip + Object.keys(data));
             });
+
+            for (var i=0; i< validPinValues.length; i++) {
+                $("#pinform input[value="+validPinValues[i]+"]").on("change", function (evt) {
+                    $("#node-input-pin").val(evt.currentTarget.value);
+                    $("#node-input-pin").removeClass("input-error");
+                });
+            }
             $("#node-input-pin").on("change", function() {
-                if ($("#node-input-pin").val() && isInt($("#node-input-pin").val())) {
-                    $("#pinform input[value="+$("#node-input-pin").val()+"]").prop('checked', true);
-                } else {
-                    var values = Object.values(bcm2pin);
-                    for (var i=0; i< values.length; i++) {
-                        $("#pinform input[value="+values[i]+"]").prop('checked', false);
-                    }
-                }
                 var pinnew = $("#node-input-pin").val();
+                if (pinnew && isInt(pinnew) && validPinValues.includes(pinnew)) {
+                    $("#pinform input[value="+pinnew+"]").prop('checked', true);
+                } else {
+                    uncheckAll();
+                }
                 if ((pinnew) && (pinnew !== pinnow)) {
                     if (pinsInUse.hasOwnProperty(pinnew)) {
                         RED.notify(pinname+" "+pinnew+" "+alreadyuse,"warn");
@@ -276,9 +284,7 @@
 
 <script type="text/html" data-template-name="rpi-gpio out">
     <div class="form-row" style="min-width: 540px">
-        <label>&nbsp;&nbsp;&nbsp;&nbsp;<span data-i18n="rpi-gpio.pinname"></span></label>
-        <input type="text" id="node-input-pin">
-        <div><p></p><div><label></label>
+        <label><i class="fa fa-circle"></i> <span data-i18n="rpi-gpio.pinname"></span></label>
         <div class="rpi-gpio-pinTable">
             <div class="pinTableBody" id="pinform">
                 <div class="pinTableRow">
@@ -364,7 +370,10 @@
             </div>
         </div>
     </div>
-    <div><p></p><div><label></label>
+    <div class="form-row">
+        <label>&nbsp;&nbsp;&nbsp;&nbsp;</label>
+        <input type="text" id="node-input-pin" style="width: 352px">
+    </div>
     <div class="form-row" id="node-set-pwm">
         <label>&nbsp;&nbsp;&nbsp;&nbsp;<span data-i18n="rpi-gpio.label.type"></span></label>
         <select id="node-input-out" style="width: 250px;">
@@ -404,20 +413,23 @@
         "5":"29", "6":"31", "12":"32", "13":"33", "19":"35", "16":"36", "26":"37", "20":"38", "21":"40"
     };
     var pinsInUse = {};
+    var validPinValues = Object.values(bcm2pin);
     var isEnvVar = function (value) {
-        var re = /^\s*\${\s*([0-9a-zA-Z_]+)\s*}\s*/;
+        var re = /^\${([0-9a-zA-Z_]+)}$/;
         var match = value.match(re);
-        if (match) {
-            return "${" + match[1] + "}";
-        }
-        return "";
+        return Boolean(match);
     };
     var isInt = function (value) {
         return parseInt(value).toString() === value.trim();
+    };
+    var uncheckAll = function() {
+        for (var i=0; i< validPinValues.length; i++) {
+            $("#pinform input[value="+validPinValues[i]+"]").prop('checked', false);
+        }
     }
     var validatePin = function (value) {
-        return isEnvVar(value) || isInt(value);
-    }
+        return isEnvVar(value) || (isInt(value) && validPinValues.includes(value));
+    };
     RED.nodes.registerType('rpi-gpio out',{
         category: 'Raspberry Pi',
         color:"#c6dbef",
@@ -465,16 +477,19 @@
                 $('#pin-tip').html(pintip + Object.keys(data));
             });
 
+            for (var i=0; i< validPinValues.length; i++) {
+                $("#pinform input[value="+validPinValues[i]+"]").on("change", function (evt) {
+                    $("#node-input-pin").val(evt.currentTarget.value);
+                    $("#node-input-pin").removeClass("input-error");
+                });
+            }
             $("#node-input-pin").on("change", function() {
-                if ($("#node-input-pin").val() && isInt($("#node-input-pin").val())) {
-                    $("#pinform input[value="+$("#node-input-pin").val()+"]").prop('checked', true);
-                } else {
-                    var values = Object.values(bcm2pin);
-                    for (var i=0; i< values.length; i++) {
-                        $("#pinform input[value="+values[i]+"]").prop('checked', false);
-                    }
-                }
                 var pinnew = $("#node-input-pin").val();
+                if (pinnew && isInt(pinnew) && validPinValues.includes(pinnew)) {
+                    $("#pinform input[value="+pinnew+"]").prop('checked', true);
+                } else {
+                    uncheckAll();
+                }
                 if ((pinnew) && (pinnew !== pinnow)) {
                     if (pinsInUse.hasOwnProperty(pinnew)) {
                         RED.notify(pinname+" "+pinnew+" "+alreadyuse,"warn");

--- a/hardware/PiGpio/36-rpi-gpio.html
+++ b/hardware/PiGpio/36-rpi-gpio.html
@@ -70,8 +70,9 @@
 <script type="text/html" data-template-name="rpi-gpio in">
 
     <div class="form-row" style="min-width: 540px">
-        <label><i class="fa fa-circle"></i> <span data-i18n="rpi-gpio.pinname"></span></label>
-        <input type="text" id="node-input-pin" style="display:none;">
+        <label>&nbsp;&nbsp;&nbsp;&nbsp;<span data-i18n="rpi-gpio.pinname"></span></label>
+        <input type="text" id="node-input-pin">
+        <div><p></p><div><label></label>
         <div class="rpi-gpio-pinTable">
             <div class="pinTableBody" id="pinform">
                 <div class="pinTableRow">
@@ -157,6 +158,7 @@
             </div>
         </div>
     </div>
+    <div><p></p><div><label></label>
     <div class="form-row">
         <label for="node-input-intype"><i class="fa fa-level-up"></i> <span data-i18n="rpi-gpio.label.resistor"></span></label>
         <select type="text" id="node-input-intype" style="width:100px;">
@@ -187,12 +189,26 @@
         "5":"29", "6":"31", "12":"32", "13":"33", "19":"35", "16":"36", "26":"37", "20":"38", "21":"40"
     };
     var pinsInUse = {};
+    var isEnvVar = function (value) {
+        var re = /^\s*\${\s*([0-9a-zA-Z_]+)\s*}\s*/;
+        var match = value.match(re);
+        if (match) {
+            return "${" + match[1] + "}";
+        }
+        return "";
+    };
+    var isInt = function (value) {
+        return parseInt(value).toString() === value.trim();
+    }
+    var validatePin = function (value) {
+        return isEnvVar(value) || isInt(value);
+    }
     RED.nodes.registerType('rpi-gpio in',{
         category: 'Raspberry Pi',
         color:"#c6dbef",
         defaults: {
             name: { value:"" },
-            pin: { value:"tri",required:true,validate:RED.validators.number() },
+            pin: { value:"tri",required:true,validate:validatePin },
             intype: { value:"tri" },
             debounce: { value:"25" },
             read: { value:false }
@@ -228,8 +244,13 @@
                 $('#pin-tip').html(pintip + Object.keys(data));
             });
             $("#node-input-pin").on("change", function() {
-                if ($("#node-input-pin").val()) {
+                if ($("#node-input-pin").val() && isInt($("#node-input-pin").val())) {
                     $("#pinform input[value="+$("#node-input-pin").val()+"]").prop('checked', true);
+                } else {
+                    var values = Object.values(bcm2pin);
+                    for (var i=0; i< values.length; i++) {
+                        $("#pinform input[value="+values[i]+"]").prop('checked', false);
+                    }
                 }
                 var pinnew = $("#node-input-pin").val();
                 if ((pinnew) && (pinnew !== pinnow)) {
@@ -255,8 +276,9 @@
 
 <script type="text/html" data-template-name="rpi-gpio out">
     <div class="form-row" style="min-width: 540px">
-        <label><i class="fa fa-circle"></i> <span data-i18n="rpi-gpio.pinname"></span></label>
-        <input type="text" id="node-input-pin" style="display:none;">
+        <label>&nbsp;&nbsp;&nbsp;&nbsp;<span data-i18n="rpi-gpio.pinname"></span></label>
+        <input type="text" id="node-input-pin">
+        <div><p></p><div><label></label>
         <div class="rpi-gpio-pinTable">
             <div class="pinTableBody" id="pinform">
                 <div class="pinTableRow">
@@ -342,6 +364,7 @@
             </div>
         </div>
     </div>
+    <div><p></p><div><label></label>
     <div class="form-row" id="node-set-pwm">
         <label>&nbsp;&nbsp;&nbsp;&nbsp;<span data-i18n="rpi-gpio.label.type"></span></label>
         <select id="node-input-out" style="width: 250px;">
@@ -381,12 +404,26 @@
         "5":"29", "6":"31", "12":"32", "13":"33", "19":"35", "16":"36", "26":"37", "20":"38", "21":"40"
     };
     var pinsInUse = {};
+    var isEnvVar = function (value) {
+        var re = /^\s*\${\s*([0-9a-zA-Z_]+)\s*}\s*/;
+        var match = value.match(re);
+        if (match) {
+            return "${" + match[1] + "}";
+        }
+        return "";
+    };
+    var isInt = function (value) {
+        return parseInt(value).toString() === value.trim();
+    }
+    var validatePin = function (value) {
+        return isEnvVar(value) || isInt(value);
+    }
     RED.nodes.registerType('rpi-gpio out',{
         category: 'Raspberry Pi',
         color:"#c6dbef",
         defaults: {
             name: { value:"" },
-            pin: { value:"",required:true,validate:RED.validators.number() },
+            pin: { value:"",required:true,validate:validatePin },
             set: { value:"" },
             level: { value:"0" },
             freq: {value:""},
@@ -429,8 +466,13 @@
             });
 
             $("#node-input-pin").on("change", function() {
-                if ($("#node-input-pin").val()) {
+                if ($("#node-input-pin").val() && isInt($("#node-input-pin").val())) {
                     $("#pinform input[value="+$("#node-input-pin").val()+"]").prop('checked', true);
+                } else {
+                    var values = Object.values(bcm2pin);
+                    for (var i=0; i< values.length; i++) {
+                        $("#pinform input[value="+values[i]+"]").prop('checked', false);
+                    }
                 }
                 var pinnew = $("#node-input-pin").val();
                 if ((pinnew) && (pinnew !== pinnow)) {


### PR DESCRIPTION
The "pin" input field is exposed so that the pin number may be typed in
directly (as opposed to selecting it from the pin table), and also
environment variables may be used to define the pin number. This, in turn,
enables the use of the GPIO pins a subflow template such that multiple
sublfow instances of that template can be running in the same Raspberry Pi
with different pin numbers.

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
