### PR TITLE
Fixed mail disposition issue for both `SEEN` and `Deleted` after read.

### DIFF
--- a/social/email/61-email.js
+++ b/social/email/61-email.js
@@ -414,9 +414,9 @@ module.exports = function(RED) {
                                             s = false;
                                             setInputRepeatTimeout();
                                         };
-                                        if (this.disposition === "Delete") {
+                                        if (node.disposition === "Delete") {
                                             imap.addFlags(results, "\Deleted", cleanup);
-                                        } else if (this.disposition === "Read") {
+                                        } else if (node.disposition === "Read") {
                                             imap.addFlags(results, "\Seen", cleanup);
                                         } else {
                                             cleanup();


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
Fixed the issue mentioned in #650 , actually it's not working for both `SEEN` and `Deleted` defined in disposition in any IMAP mail server.
The bug is easy to fix, just use `node` to replace `this` in closure.
 
<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
