### PR TITLE
Update node-red-random to add option to dynamically pass in 'To' and 'From'

### DIFF
--- a/function/random/README.md
+++ b/function/random/README.md
@@ -19,4 +19,6 @@ If set to return an integer it can include both the low and high values.
 If set to return a floating point value it will be from the low value, up to, but
 **not** including the high value. `min <= n < max` - so selecting 1 to 6 will return values 1 <= n < 6 .
 
+You can dynamically pass in the 'From' and 'To' values to the node using msg.to and/or msg.from. **NOTE:** hard coded values in the node **always take precedence**.
+
 **Note:** This returns numbers - objects of type **number**.

--- a/function/random/locales/en-US/random.html
+++ b/function/random/locales/en-US/random.html
@@ -1,7 +1,14 @@
 <script type="text/html" data-help-name="random">
-    <p>Generates a random number between a low and high value.</p>
+    <p>Generates a random number between a low and high value. Defaults to 1 to 10.</p>
     <p>If set to return an integer it can <i>include</i> both the low and high values.
     <code>min <= n <= max</code></p>
     <p>If set to return a floating point value it will be from the low value, up to, but
     not including the high value. <code>min <= n < max</code></p>
+    <p><b>Inputs</b></p>
+    <p>You can dynamically pass in the 'From' and 'To' values to the node. <b>NOTE:</b> hard coded values in the node <b>always take precedence.</b>
+    <ul>
+    <i><b>From</b> [msg.from] Number containing the low value to be used.</i>
+    <br>
+    <i><b>To</b> [msg.to] Number containing the high value to be used.</i>
+    </ul>
 </script>

--- a/function/random/random.html
+++ b/function/random/random.html
@@ -31,8 +31,8 @@
         color:"#E2D96E",
         defaults: {
             name: {value:""},
-            low: {value:""},
-            high: {value:""},
+            low:  {value:"",validate:function(v) { return  !isNaN(v) || v.length === 0;} },
+            high: {value:"",validate:function(v) { return  !isNaN(v) || v.length === 0;} },
             inte: {value:"true"},
             property: {value:"payload",required:true}
         },

--- a/function/random/random.html
+++ b/function/random/random.html
@@ -31,8 +31,8 @@
         color:"#E2D96E",
         defaults: {
             name: {value:""},
-            low: {value:"1"},
-            high: {value:"10"},
+            low: {value:""},
+            high: {value:""},
             inte: {value:"true"},
             property: {value:"payload",required:true}
         },

--- a/function/random/random.html
+++ b/function/random/random.html
@@ -31,8 +31,8 @@
         color:"#E2D96E",
         defaults: {
             name: {value:""},
-            low:  {value:"",validate:function(v) { return  !isNaN(v) || v.length === 0;} },
-            high: {value:"",validate:function(v) { return  !isNaN(v) || v.length === 0;} },
+            low:  {value: 1,validate:function(v) { return  !isNaN(v) || v.length === 0;} },
+            high: {value: 10,validate:function(v) { return  !isNaN(v) || v.length === 0;} },
             inte: {value:"true"},
             property: {value:"payload",required:true}
         },

--- a/function/random/random.js
+++ b/function/random/random.js
@@ -3,13 +3,44 @@ module.exports = function(RED) {
     "use strict";
     function RandomNode(n) {
         RED.nodes.createNode(this,n);
-        this.low = Number(n.low || 1);
-        this.high = Number(n.high || 10);
+
+        this.low  = Number(n.low) || ""; 
+        this.high = Number(n.high) || "";
         this.inte = n.inte || false;
         this.property = n.property||"payload";
         var node = this;
+        
+      
         this.on("input", function(msg) {
+
+            if (node.low === "") {
+                node.low = 1
+                if ('from' in msg) {
+                    if ( (typeof msg.from === 'number') 
+                    || ( (typeof msg.from === 'string') && (!isNaN(Number(msg.from)) ) )) {
+                        node.low = Number(msg.from)
+                    }
+                } 
+            }
+    
+            if (node.high === "") {
+                node.high = 10 
+                if ('to' in msg) {
+                    if ( (typeof msg.to === 'number') 
+                    || ( (typeof msg.to === 'string') && (!isNaN(Number(msg.to)) ) )) {
+                        node.high = Number(msg.to)
+                    }
+                } 
+            }
+            
+            // flip the values if low > high
             var value;
+            if (node.low > node.high) {  
+                value = node.low
+                node.low = node.high
+                node.high = value
+            }
+
             if (node.inte == "true" || node.inte === true) {
                 value = Math.round(Math.random() * (node.high - node.low + 1) + node.low - 0.5);
             }

--- a/function/random/random.js
+++ b/function/random/random.js
@@ -12,7 +12,6 @@ module.exports = function(RED) {
         var tmp = {};
 
         this.on("input", function(msg) {
-          this.status({}); // blank out the status on a deploy
 
           tmp.low = 1                 // set this as the default low value
           tmp.low_e = ""
@@ -69,7 +68,6 @@ module.exports = function(RED) {
              }
             
              RED.util.setMessageProperty(msg,node.property,value);
-             this.status({fill:"grey",shape:"dot",text:"random: from " + tmp.low + " to " + tmp.high});
              node.send(msg);
           }
         });

--- a/function/random/random.js
+++ b/function/random/random.js
@@ -15,31 +15,34 @@ module.exports = function(RED) {
           this.status({}); // blank out the status on a deploy
 
           tmp.low = 1                 // set this as the default low value
+          tmp.low_e = ""
           if (node.low) {             // if the the node has a value use it
               tmp.low = node.low
           } else if ('from' in msg) { // else see if a 'from' is in the msg
               if (Number(msg.from)) { // if it is, and is a number, use it
                   tmp.low = Number(msg.from);
               } else {                // otherwise setup NaN error
-                  tmp.low = NaN
+                  tmp.low = NaN;
+                  tmp.low_e = " From: " + msg.from; // setup to show bad incoming msg.from
               }
           } 
               
           tmp.high = 10               // set this as the default high value  
-          if (node.high) {            // if the the node has a value use it
+          tmp.high_e = "";
+          if (node.high) {            // if the the node has a value use it 
               tmp.high = node.high
           } else if ('to' in msg) {   // else see if a 'to' is in the msg
               if (Number(msg.to)) {   // if it is, and is a number, use it
                   tmp.high = Number(msg.to);
               } else {                // otherwise setup NaN error 
                   tmp.high = NaN
+                  tmp.high_e = " To: " + msg.to // setup to show bad incoming msg.to
               }
           } 
                            
-          // if tmp.low or high are not numbers, send an error msg
+          // if tmp.low or high are not numbers, send an error msg with bad values
           if ( (isNaN(tmp.low)) || (isNaN(tmp.high)) ) {
-              this.status({fill:"red",shape:"dot",text:"random: from " + Number(tmp.low) + " to " + Number(tmp.high)})
-              this.error("Random: one of the input values is not a number")
+              this.error("Random: one of the input values is not a number. " + tmp.low_e + tmp.high_e);
           } else {
           // at this point we have valid values so now to generate the random number! 
 

--- a/function/random/random.js
+++ b/function/random/random.js
@@ -16,8 +16,7 @@ module.exports = function(RED) {
             if (node.low === "") {
                 node.low = 1
                 if ('from' in msg) {
-                    if ( (typeof msg.from === 'number') 
-                    || ( (typeof msg.from === 'string') && (!isNaN(Number(msg.from)) ) )) {
+                    if ( (typeof msg.from === 'number') || ( (typeof msg.from === 'string') && (!isNaN(Number(msg.from)) ) )) {
                         node.low = Number(msg.from)
                     }
                 } 
@@ -26,8 +25,7 @@ module.exports = function(RED) {
             if (node.high === "") {
                 node.high = 10 
                 if ('to' in msg) {
-                    if ( (typeof msg.to === 'number') 
-                    || ( (typeof msg.to === 'string') && (!isNaN(Number(msg.to)) ) )) {
+                    if ( (typeof msg.to === 'number') || ( (typeof msg.to === 'string') && (!isNaN(Number(msg.to)) ) )) {
                         node.high = Number(msg.to)
                     }
                 } 

--- a/function/random/random.js
+++ b/function/random/random.js
@@ -9,31 +9,32 @@ module.exports = function(RED) {
         this.inte = n.inte || false;
         this.property = n.property||"payload";
         var node = this;
-        var tmp = {};  
+        var tmp = {};
 
         this.on("input", function(msg) {
 
-           if (node.low === "") {
-               tmp.low = 1;
-               if ('from' in msg) {
-                 tmp.low = msg.from} 
+           if (node.low) {            // if the the node has a value use it
+               tmp.low = node.low
+           } else {                   // if 'from' in the msg, use it or default to 1
+               tmp.low = ('from' in msg) ? msg.from : 1;
            }
-                
-           if (node.high === "") {
-               tmp.high = 10; 
-               if ('to' in msg) {tmp.high = msg.to} 
+
+           if (node.high) {           // if the the node has a value use it
+               tmp.high = node.high
+           } else {                   // if 'to' in the msg, use it or default to 1
+               tmp.high = ('to' in msg) ? msg.to : 10;
            }
            
-          // if tmp.low or tmp.high is not a number flag an error and do not send out a msg
+          // if tmp.low or high are not numbers, send an error msg
           if ( (isNaN(tmp.low)) || (isNaN(tmp.high)) ) {
               this.error({node:"random",text:"one of the input values is not a number"})
           } 
           else {
-          // force tmp.high/low to Numbers since they may be a string
+             // force tmp.high/low to Numbers since they may be a string
              tmp.low = Number(tmp.low)
              tmp.high = Number(tmp.high)
 
-           // flip the values if low > high so random will work
+             // flip the values if low > high so random will work
              var value = 0;
              if (tmp.low > tmp.high) {  
                  value = tmp.low
@@ -41,9 +42,9 @@ module.exports = function(RED) {
                  tmp.high = value
              }
 
-           // if returning an integer, do a parseInt() on the low and high values
-           // before generate the random number. This must be done to insure the rounding
-           // doesn't go up if using something like 4.7 or you can end up with 5
+             // if returning an integer, do a parseInt() on the low and high values
+             // before generate the random number. This must be done to insure the rounding
+             // doesn't go up if using something like 4.7 or you can end up with 5
              if ( (node.inte == "true") || (node.inte === true) ) {
                  tmp.low  = parseInt(tmp.low);
                  tmp.high = parseInt(tmp.high);
@@ -55,7 +56,7 @@ module.exports = function(RED) {
              RED.util.setMessageProperty(msg,node.property,value);
 
              node.send(msg);
-           }
+          }
         });
     }
     RED.nodes.registerType("random",RandomNode);

--- a/function/random/random.js
+++ b/function/random/random.js
@@ -4,49 +4,63 @@ module.exports = function(RED) {
     function RandomNode(n) {
         RED.nodes.createNode(this,n);
 
-        this.low  = Number(n.low) || ""; 
-        this.high = Number(n.high) || "";
+        this.status({}); // blank status on a deploy
+
         this.inte = n.inte || false;
         this.property = n.property||"payload";
         var node = this;
-        
-      
+
+
         this.on("input", function(msg) {
+ 
+           if (n.low !== "") {this.low  = parseFloat(n.low)}
+              else {this.low = n.low}; 
+           if (n.high !== "") {this.high  = parseFloat(n.high)}
+              else {this.high = n.high}; 
+      
+           if (node.low === "") {
+               node.low = 1;
+               if ('from' in msg) {node.low = msg.from} 
+           }
+                
+           if (node.high === "") {
+               node.high = 10; 
+               if ('to' in msg) {node.high = msg.to} 
+           }
 
-            if (node.low === "") {
-                node.low = 1
-                if ('from' in msg) {
-                    if ( (typeof msg.from === 'number') || ( (typeof msg.from === 'string') && (!isNaN(Number(msg.from)) ) )) {
-                        node.low = Number(msg.from)
-                    }
-                } 
-            }
-    
-            if (node.high === "") {
-                node.high = 10 
-                if ('to' in msg) {
-                    if ( (typeof msg.to === 'number') || ( (typeof msg.to === 'string') && (!isNaN(Number(msg.to)) ) )) {
-                        node.high = Number(msg.to)
-                    }
-                } 
-            }
+           // if returning an interger, do a parseInt() on the low and high values
+           if ( (node.inte == "true") || (node.inte === true) ) {
+               node.low  = parseInt(node.low);
+               node.high = parseInt(node.high);
+           }
+
+           // flip the values if low > high so random will work
+           var value;
+           if (node.low > node.high) {  
+               value = node.low
+               node.low = node.high
+               node.high = value
+           }
+           // generate the random number
+           if ( (node.inte == "true") || (node.inte === true) ) {
+               node.low  = Math.round(node.low)
+               node.high = Math.round(node.high)
+               value = Math.round(Math.random() * (node.high - node.low + 1) + node.low - 0.5);
+           } else {
+               value = Math.random() * (node.high - node.low) + node.low;
+           }
             
-            // flip the values if low > high
-            var value;
-            if (node.low > node.high) {  
-                value = node.low
-                node.low = node.high
-                node.high = value
-            }
+           RED.util.setMessageProperty(msg,node.property,value);
 
-            if (node.inte == "true" || node.inte === true) {
-                value = Math.round(Math.random() * (node.high - node.low + 1) + node.low - 0.5);
-            }
-            else {
-                value = Math.random() * (node.high - node.low) + node.low;
-            }
-            RED.util.setMessageProperty(msg,node.property,value);
-            node.send(msg);
+           // output a status under the node
+           var color = "grey";
+           if ( (isNaN(node.low)) || (isNaN(node.high)) ) {
+              this.status({fill:"red",shape:"dot",text:"random: from " + node.low + " to " + node.high})
+              this.error({node:"random",text:"one of the input values is not a number"})
+           } else {
+              this.status({fill:"grey",shape:"dot",text:"random: from " + node.low + " to " + node.high + " value=" + value});
+              node.send(msg);
+           }
         });
     }
     RED.nodes.registerType("random",RandomNode);

--- a/function/random/random.js
+++ b/function/random/random.js
@@ -12,27 +12,36 @@ module.exports = function(RED) {
         var tmp = {};
 
         this.on("input", function(msg) {
+          this.status({}); // blank out the status on a deploy
 
-           if (node.low) {            // if the the node has a value use it
-               tmp.low = node.low
-           } else {                   // if 'from' in the msg, use it or default to 1
-               tmp.low = ('from' in msg) ? msg.from : 1;
-           }
-
-           if (node.high) {           // if the the node has a value use it
-               tmp.high = node.high
-           } else {                   // if 'to' in the msg, use it or default to 1
-               tmp.high = ('to' in msg) ? msg.to : 10;
-           }
-           
+          tmp.low = 1                 // set this as the default low value
+          if (node.low) {             // if the the node has a value use it
+              tmp.low = node.low
+          } else if ('from' in msg) { // else see if a 'from' is in the msg
+              if (Number(msg.from)) { // if it is, and is a number, use it
+                  tmp.low = Number(msg.from);
+              } else {                // otherwise setup NaN error
+                  tmp.low = NaN
+              }
+          } 
+              
+          tmp.high = 10               // set this as the default high value  
+          if (node.high) {            // if the the node has a value use it
+              tmp.high = node.high
+          } else if ('to' in msg) {   // else see if a 'to' is in the msg
+              if (Number(msg.to)) {   // if it is, and is a number, use it
+                  tmp.high = Number(msg.to);
+              } else {                // otherwise setup NaN error 
+                  tmp.high = NaN
+              }
+          } 
+                           
           // if tmp.low or high are not numbers, send an error msg
           if ( (isNaN(tmp.low)) || (isNaN(tmp.high)) ) {
-              this.error({node:"random",text:"one of the input values is not a number"})
-          } 
-          else {
-             // force tmp.high/low to Numbers since they may be a string
-             tmp.low = Number(tmp.low)
-             tmp.high = Number(tmp.high)
+              this.status({fill:"red",shape:"dot",text:"random: from " + Number(tmp.low) + " to " + Number(tmp.high)})
+              this.error("Random: one of the input values is not a number")
+          } else {
+          // at this point we have valid values so now to generate the random number! 
 
              // flip the values if low > high so random will work
              var value = 0;
@@ -42,19 +51,22 @@ module.exports = function(RED) {
                  tmp.high = value
              }
 
-             // if returning an integer, do a parseInt() on the low and high values
-             // before generate the random number. This must be done to insure the rounding
-             // doesn't go up if using something like 4.7 or you can end up with 5
+             // if returning an integer, do a math.ceil() on the low value and a 
+             // Math.floor()high value before generate the random number. This must be 
+             // done to insure the rounding doesn't round up if using something like 4.7
+             // which would end up with 5
              if ( (node.inte == "true") || (node.inte === true) ) {
-                 tmp.low  = parseInt(tmp.low);
-                 tmp.high = parseInt(tmp.high);
+                 tmp.low  = Math.ceil(tmp.low);
+                 tmp.high = Math.floor(tmp.high);
+                 // use this to round integers
                  value = Math.round(Math.random() * (tmp.high - tmp.low + 1) + tmp.low - 0.5);
              } else {
+                 // use this to round floats
                  value = (Math.random() * (tmp.high - tmp.low)) + tmp.low;
              }
             
              RED.util.setMessageProperty(msg,node.property,value);
-
+             this.status({fill:"grey",shape:"dot",text:"random: from " + tmp.low + " to " + tmp.high});
              node.send(msg);
           }
         });

--- a/test/function/random/random_spec.js
+++ b/test/function/random/random_spec.js
@@ -21,8 +21,8 @@ describe('random node', function() {
         helper.load(testNode, flow, function() {
             var n1 = helper.getNode("n1");
             //console.log(n1);
-            n1.should.have.property("low", 1);
-            n1.should.have.property("high", 10);
+            n1.should.have.property("low", "");
+            n1.should.have.property("high", "");
             n1.should.have.property("inte", false);
             done();
         });

--- a/test/function/random/random_spec.js
+++ b/test/function/random/random_spec.js
@@ -15,74 +15,295 @@ describe('random node', function() {
             helper.stopServer(done);
         });
     });
+    
+// ============================================================
 
-    it("should be loaded with correct defaults", function(done) {
-        var flow = [{"id":"n1", "type":"random", "name":"random1", "wires":[[]]}];
-        helper.load(testNode, flow, function() {
-            var n1 = helper.getNode("n1");
-            //console.log(n1);
-            n1.should.have.property("low", "");
-            n1.should.have.property("high", "");
-            n1.should.have.property("inte", false);
-            done();
-        });
-    });
-
-    it('should output an integer between -3 and 3', function(done) {
-        var flow = [{"id":"n1", "type":"random", low:-3, high:3, inte:true, wires:[["n2"]] },
+   it ("Test i1 (integer) - DEFAULT no overrides defaults to 1 and 10", function(done) {  
+        var flow = [{id:"n1", type:"random", low: "" , high:"" , inte:true, wires:[["n2"]] },  
             {id:"n2", type:"helper"} ];
-        helper.load(testNode, flow, function() {
+        helper.load(testNode, flow, function() { 
             var n1 = helper.getNode("n1");
             var n2 = helper.getNode("n2");
-            var c = 0;
-            n2.on("input", function(msg) {
-                if (c === 0) {
-                    msg.should.have.a.property("payload");
-                    msg.payload.should.be.approximately(0,3);
-                    msg.payload.toString().indexOf(".").should.equal(-1);
-                    done();
+            n2.on("input", function(msg) {  
+                try {
+                    //console.log(msg);    
+                    msg.should.have.a.property("payload");       
+                    msg.payload.should.be.within(1,10);     
+                    msg.payload.toString().indexOf(".").should.equal(-1); // see if it's really an integer and not a float...
+                    done(); 
                 }
+                catch(err) { done(err); }   
             });
-            n1.emit("input", {payload:"a"});
+            n1.emit("input", {"test":"Test i1"});  
         });
     });
 
-    it('should output an float between 20 and 30', function(done) {
-        var flow = [{"id":"n1", "type":"random", low:20, high:30, inte:false, wires:[["n2"]] },
+   it ("Test f1 (float)   - DEFAULT no overrides defaults to 1 and 10", function(done) {  
+        var flow = [{id:"n1", type:"random", low:"" , high:"" , inte:false, wires:[["n2"]] },  
             {id:"n2", type:"helper"} ];
-        helper.load(testNode, flow, function() {
+        helper.load(testNode, flow, function() { 
             var n1 = helper.getNode("n1");
             var n2 = helper.getNode("n2");
-            var c = 0;
-            n2.on("input", function(msg) {
-                if (c === 0) {
-                    msg.should.have.a.property("payload");
-                    msg.payload.should.be.approximately(25,5);
-                    msg.payload.toString().indexOf(".").should.not.equal(-1);
-                    done();
+            n2.on("input", function(msg) {  
+                try {
+                    //console.log(msg);    
+                    msg.should.have.a.property("payload");       
+                    msg.payload.should.be.within(1.0,9.999);     
+                    //msg.payload.toString().indexOf(".").should.not.equal(-1); 
+                    done(); 
                 }
+                catch(err) { done(err); }   
             });
-            n1.emit("input", {payload:"a"});
+            n1.emit("input", {"test":"Test f-1"});  
         });
     });
 
-    it('should output an integer between -3 and 3 on chosen property - foo', function(done) {
-        var flow = [{"id":"n1", "type":"random", property:"foo", low:-3, high:3, inte:true, wires:[["n2"]] },
+// ============================================================
+
+   it ("Test i2 (integer) - FLIP node From = 3 To = -3", function(done) {  
+        var flow = [{id:"n1", type:"random", low: 3, high: -3, inte:true, wires:[["n2"]] },  
             {id:"n2", type:"helper"} ];
-        helper.load(testNode, flow, function() {
+        helper.load(testNode, flow, function() { 
             var n1 = helper.getNode("n1");
             var n2 = helper.getNode("n2");
-            var c = 0;
-            n2.on("input", function(msg) {
-                if (c === 0) {
-                    msg.should.have.a.property("foo");
-                    msg.foo.should.be.approximately(0,3);
-                    msg.foo.toString().indexOf(".").should.equal(-1);
-                    done();
+            n2.on("input", function(msg) {  
+                try {
+                    //console.log(msg);    
+                    msg.should.have.a.property("payload");       
+                    msg.payload.should.be.within(-3,3);     
+                    msg.payload.toString().indexOf(".").should.equal(-1); // slightly dumb test to see if it really is an integer and not a float...
+                    done(); 
                 }
+                catch(err) { done(err); }   
             });
-            n1.emit("input", {payload:"a"});
+            n1.emit("input", {"test":"Test i2"});  
         });
     });
 
+   it ("Test f2 (float)   - FLIP node From = 3 To = -3", function(done) {  
+        var flow = [{id:"n1", type:"random", low: 3, high: -3, inte:false, wires:[["n2"]] },  
+            {id:"n2", type:"helper"} ];
+        helper.load(testNode, flow, function() { 
+            var n1 = helper.getNode("n1");
+            var n2 = helper.getNode("n2");
+            n2.on("input", function(msg) {  
+                try {
+                    //console.log(msg);    
+                    msg.should.have.a.property("payload");       
+                    msg.payload.should.be.within(-3.0,3.0);     
+                    done(); 
+                }
+                catch(err) { done(err); }   
+            });
+            n1.emit("input", {"test":"Test f2"});  
+        });
+    });
+
+// ============================================================
+
+   it ("Test i3 (integer) - values in msg From = 2 To = '5', node no entries", function(done) {  
+        var flow = [{id:"n1", type:"random", low: "", high: "", inte:true, wires:[["n2"]] },  
+            {id:"n2", type:"helper"} ];
+        helper.load(testNode, flow, function() { 
+            var n1 = helper.getNode("n1");
+            var n2 = helper.getNode("n2");
+            n2.on("input", function(msg) {  
+                try {
+                    //console.log(msg);    
+                    msg.should.have.a.property("payload");       
+                    msg.payload.should.be.within(2,5);     
+                    msg.payload.toString().indexOf(".").should.equal(-1); // slightly dumb test to see if it really is an integer and not a float...
+                    done(); 
+                }
+                catch(err) { done(err); }   
+            });
+            n1.emit("input", {"test":"Test i3", "from":2, "to":'5'});  
+        });
+    });
+
+   it ("Test f3 (float)   - values in msg From = 2 To = '5', node no entries", function(done) {  
+        var flow = [{id:"n1", type:"random", low: "", high: "", inte:false, wires:[["n2"]] },  
+            {id:"n2", type:"helper"} ];
+        helper.load(testNode, flow, function() { 
+            var n1 = helper.getNode("n1");
+            var n2 = helper.getNode("n2");
+            n2.on("input", function(msg) {  
+                try {
+                    //console.log(msg);    
+                    msg.should.have.a.property("payload");       
+                    msg.payload.should.be.within(2.0,5.0);     
+                    done(); 
+                }
+                catch(err) { done(err); }   
+            });
+            n1.emit("input", {"test":"Test f3", "from":2, "to":'5'});  
+        });
+    });
+
+// ============================================================
+
+   it ("Test i4 (integer) - node From = 2 To = '-2', values will flip", function(done) {  
+        var flow = [{id:"n1", type:"random", low: 2, high: "-2", inte:true, wires:[["n2"]] },  
+            {id:"n2", type:"helper"} ];
+        helper.load(testNode, flow, function() { 
+            var n1 = helper.getNode("n1");
+            var n2 = helper.getNode("n2");
+            n2.on("input", function(msg) {  
+                try {
+                    //console.log(msg);    
+                    msg.should.have.a.property("payload");       
+                    msg.payload.should.be.within(-2,2);     
+                    msg.payload.toString().indexOf(".").should.equal(-1); 
+                    done(); 
+                }
+                catch(err) { done(err); }   
+            });
+            n1.emit("input", {"test":"Test i4"});  
+        });
+    });
+
+   it ("Test f4 (float)   - node From = 2 To = '-2', values will flip", function(done) {  
+        var flow = [{id:"n1", type:"random", low: 2, high: "-2", inte:false, wires:[["n2"]] },  
+            {id:"n2", type:"helper"} ];
+        helper.load(testNode, flow, function() { 
+            var n1 = helper.getNode("n1");
+            var n2 = helper.getNode("n2");
+            n2.on("input", function(msg) {  
+                try {
+                    //console.log(msg);    
+                    msg.should.have.a.property("payload");       
+                    msg.payload.should.be.within(-2.0,2.0);     
+                    done(); 
+                }
+                catch(err) { done(err); }   
+            });
+            n1.emit("input", {"test":"Test 44"});  
+        });
+    });
+
+ // ============================================================
+
+  it ("Test i5 (integer) - value in msg From = 2, node From = 5 To = '' - node overides From = 5 To defaults to 10", function(done) {  
+        var flow = [{id:"n1", type:"random", low: 5, high:"", inte:true, wires:[["n2"]] },  
+            {id:"n2", type:"helper"} ];
+        helper.load(testNode, flow, function() { 
+            var n1 = helper.getNode("n1");
+            var n2 = helper.getNode("n2");
+            n2.on("input", function(msg) {  
+                try {
+                    //console.log(msg);    
+                    msg.should.have.a.property("payload");       
+                    msg.payload.should.be.within(5,10);     
+                    msg.payload.toString().indexOf(".").should.equal(-1); 
+                    done(); 
+                }
+                catch(err) { done(err); }   
+            });
+            n1.emit("input", {"test":"Test i5", "from": 2});  
+        });
+    });
+
+  it ("Test f5 (float)   - value in msg From = 2, node From = 5 To = '' - node wins 'To' defaults to 10", function(done) {  
+        var flow = [{id:"n1", type:"random", low: 5, high:"", inte:false, wires:[["n2"]] },  
+            {id:"n2", type:"helper"} ];
+        helper.load(testNode, flow, function() { 
+            var n1 = helper.getNode("n1");
+            var n2 = helper.getNode("n2");
+            n2.on("input", function(msg) {  
+                try {
+                    //console.log(msg);    
+                    msg.should.have.a.property("payload");       
+                    msg.payload.should.be.within(5.0,10.0);     
+                    done(); 
+                }
+                catch(err) { done(err); }   
+            });
+            n1.emit("input", {"test":"Test f5", "from": 2});  
+        });
+    });
+
+// ============================================================
+
+  it ("Test i6 (integer) - msg From = '6' To = '9' node no entries", function(done) {  
+        var flow = [{id:"n1", type:"random", low: "", high: "", inte:true, wires:[["n2"]] },  
+            {id:"n2", type:"helper"} ];
+        helper.load(testNode, flow, function() { 
+            var n1 = helper.getNode("n1");
+            var n2 = helper.getNode("n2");
+            n2.on("input", function(msg) {  
+                try {
+                    //console.log(msg);    
+                    msg.should.have.a.property("payload");       
+                    msg.payload.should.be.within(6,9);     
+                    msg.payload.toString().indexOf(".").should.equal(-1); // slightly dumb test to see if it really is an integer and not a float...
+                    done(); 
+                }
+                catch(err) { done(err); }   
+            });
+            n1.emit("input", {"test":"Test i6", "from": '6', "to": '9'});  
+        });
+    });
+
+  it ("Test f6 (float)   - msg From = '6' To = '9' node no entries", function(done) {  
+        var flow = [{id:"n1", type:"random", low: "", high: "", inte:false, wires:[["n2"]] },  
+            {id:"n2", type:"helper"} ];
+        helper.load(testNode, flow, function() { 
+            var n1 = helper.getNode("n1");
+            var n2 = helper.getNode("n2");
+            n2.on("input", function(msg) {  
+                try {
+                    //console.log(msg);    
+                    msg.should.have.a.property("payload");       
+                    msg.payload.should.be.within(6.0,9.0);     
+                    done(); 
+                }
+                catch(err) { done(err); }   
+            });
+            n1.emit("input", {"test":"Test f6", "from": '6', "to": '9'});  
+        });
+    });
+
+// ============================================================
+
+  it ("Test i7 (integer) - msg From = 2.4 To = '7.3' node no entries", function(done) {  
+        var flow = [{id:"n1", type:"random", low: "", high: "", inte:true, wires:[["n2"]] },  
+            {id:"n2", type:"helper"} ];
+        helper.load(testNode, flow, function() { 
+            var n1 = helper.getNode("n1");
+            var n2 = helper.getNode("n2");
+            n2.on("input", function(msg) {  
+                try {
+                    //console.log(msg);    
+                    msg.should.have.a.property("payload");       
+                    msg.payload.should.be.within(2,7);     
+                    msg.payload.toString().indexOf(".").should.equal(-1); // slightly dumb test to see if it really is an integer and not a float...
+                    done(); 
+                }
+                catch(err) { done(err); }   
+            });
+            n1.emit("input", {"test":"Test i7", "from": 2.4, "to": '7.3'});  
+        });
+    });
+
+  it ("Test f7 (float)   - msg From = 2.4 To = '7.3' node no entries", function(done) {  
+        var flow = [{id:"n1", type:"random", low: "", high: "", inte:false, wires:[["n2"]] },  
+            {id:"n2", type:"helper"} ];
+        helper.load(testNode, flow, function() { 
+            var n1 = helper.getNode("n1");
+            var n2 = helper.getNode("n2");
+            n2.on("input", function(msg) {  
+                try {
+                    //console.log(msg);    
+                    msg.should.have.a.property("payload");       
+                    msg.payload.should.be.within(2.4,7.3);     
+                    done(); 
+                }
+                catch(err) { done(err); }   
+            });
+            n1.emit("input", {"test":"Test f7", "from": 2.4, "to": '7.3'});  
+        });
+    });
+
+// ============================================================
+   
 });

--- a/test/function/random/random_spec.js
+++ b/test/function/random/random_spec.js
@@ -140,50 +140,10 @@ describe('random node', function() {
         });
     });
 
-// ============================================================
-
-   it ("Test i4 (integer) - node From = 2 To = '-2', values will flip", function(done) {  
-        var flow = [{id:"n1", type:"random", low: 2, high: "-2", inte:true, wires:[["n2"]] },  
-            {id:"n2", type:"helper"} ];
-        helper.load(testNode, flow, function() { 
-            var n1 = helper.getNode("n1");
-            var n2 = helper.getNode("n2");
-            n2.on("input", function(msg) {  
-                try {
-                    //console.log(msg);    
-                    msg.should.have.a.property("payload");       
-                    msg.payload.should.be.within(-2,2);     
-                    msg.payload.toString().indexOf(".").should.equal(-1); 
-                    done(); 
-                }
-                catch(err) { done(err); }   
-            });
-            n1.emit("input", {"test":"Test i4"});  
-        });
-    });
-
-   it ("Test f4 (float)   - node From = 2 To = '-2', values will flip", function(done) {  
-        var flow = [{id:"n1", type:"random", low: 2, high: "-2", inte:false, wires:[["n2"]] },  
-            {id:"n2", type:"helper"} ];
-        helper.load(testNode, flow, function() { 
-            var n1 = helper.getNode("n1");
-            var n2 = helper.getNode("n2");
-            n2.on("input", function(msg) {  
-                try {
-                    //console.log(msg);    
-                    msg.should.have.a.property("payload");       
-                    msg.payload.should.be.within(-2.0,2.0);     
-                    done(); 
-                }
-                catch(err) { done(err); }   
-            });
-            n1.emit("input", {"test":"Test 44"});  
-        });
-    });
 
  // ============================================================
 
-  it ("Test i5 (integer) - value in msg From = 2, node From = 5 To = '' - node overides From = 5 To defaults to 10", function(done) {  
+  it ("Test i4 (integer) - value in msg From = 2, node From = 5 To = '' - node overides From = 5 To defaults to 10", function(done) {  
         var flow = [{id:"n1", type:"random", low: 5, high:"", inte:true, wires:[["n2"]] },  
             {id:"n2", type:"helper"} ];
         helper.load(testNode, flow, function() { 
@@ -199,11 +159,11 @@ describe('random node', function() {
                 }
                 catch(err) { done(err); }   
             });
-            n1.emit("input", {"test":"Test i5", "from": 2});  
+            n1.emit("input", {"test":"Test i4", "from": 2});  
         });
     });
 
-  it ("Test f5 (float)   - value in msg From = 2, node From = 5 To = '' - node wins 'To' defaults to 10", function(done) {  
+  it ("Test f4 (float)   - value in msg From = 2, node From = 5 To = '' - node wins 'To' defaults to 10", function(done) {  
         var flow = [{id:"n1", type:"random", low: 5, high:"", inte:false, wires:[["n2"]] },  
             {id:"n2", type:"helper"} ];
         helper.load(testNode, flow, function() { 
@@ -218,13 +178,13 @@ describe('random node', function() {
                 }
                 catch(err) { done(err); }   
             });
-            n1.emit("input", {"test":"Test f5", "from": 2});  
+            n1.emit("input", {"test":"Test f4", "from": 2});  
         });
     });
 
 // ============================================================
 
-  it ("Test i6 (integer) - msg From = '6' To = '9' node no entries", function(done) {  
+  it ("Test i5 (integer) - msg From = '6' To = '9' node no entries", function(done) {  
         var flow = [{id:"n1", type:"random", low: "", high: "", inte:true, wires:[["n2"]] },  
             {id:"n2", type:"helper"} ];
         helper.load(testNode, flow, function() { 
@@ -240,11 +200,11 @@ describe('random node', function() {
                 }
                 catch(err) { done(err); }   
             });
-            n1.emit("input", {"test":"Test i6", "from": '6', "to": '9'});  
+            n1.emit("input", {"test":"Test i5", "from": '6', "to": '9'});  
         });
     });
 
-  it ("Test f6 (float)   - msg From = '6' To = '9' node no entries", function(done) {  
+  it ("Test f5 (float)   - msg From = '6' To = '9' node no entries", function(done) {  
         var flow = [{id:"n1", type:"random", low: "", high: "", inte:false, wires:[["n2"]] },  
             {id:"n2", type:"helper"} ];
         helper.load(testNode, flow, function() { 
@@ -259,13 +219,13 @@ describe('random node', function() {
                 }
                 catch(err) { done(err); }   
             });
-            n1.emit("input", {"test":"Test f6", "from": '6', "to": '9'});  
+            n1.emit("input", {"test":"Test f5", "from": '6', "to": '9'});  
         });
     });
 
 // ============================================================
 
-  it ("Test i7 (integer) - msg From = 2.4 To = '7.3' node no entries", function(done) {  
+  it ("Test i6 (integer) - msg From = 2.4 To = '7.3' node no entries", function(done) {  
         var flow = [{id:"n1", type:"random", low: "", high: "", inte:true, wires:[["n2"]] },  
             {id:"n2", type:"helper"} ];
         helper.load(testNode, flow, function() { 
@@ -281,11 +241,11 @@ describe('random node', function() {
                 }
                 catch(err) { done(err); }   
             });
-            n1.emit("input", {"test":"Test i7", "from": 2.4, "to": '7.3'});  
+            n1.emit("input", {"test":"Test i6", "from": 2.4, "to": '7.3'});  
         });
     });
 
-  it ("Test f7 (float)   - msg From = 2.4 To = '7.3' node no entries", function(done) {  
+  it ("Test f6 (float)   - msg From = 2.4 To = '7.3' node no entries", function(done) {  
         var flow = [{id:"n1", type:"random", low: "", high: "", inte:false, wires:[["n2"]] },  
             {id:"n2", type:"helper"} ];
         helper.load(testNode, flow, function() { 
@@ -300,10 +260,12 @@ describe('random node', function() {
                 }
                 catch(err) { done(err); }   
             });
-            n1.emit("input", {"test":"Test f7", "from": 2.4, "to": '7.3'});  
+            n1.emit("input", {"test":"Test f6", "from": 2.4, "to": '7.3'});  
         });
     });
 
 // ============================================================
+
+
    
 });


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This update allows the user to set the 'To' and 'From' values in an incoming msg as 'msg.to' and 'msg.from'. In my use case, I wanted to pick a random file from a number of folders each with a different number of files. Without this change, I would need to have one random node for each folder and would have to change the hard coded values if a file was added or remove from the folder.

In addition, I discovered a but where if 'From' was greater than 'To' you would only get numbers between them. So if 'From' was 3 and 'To' was 1 you wold only receive 2.
 
## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
