### PR TITLE
Improve error handling for read-only applications

### DIFF
--- a/social/twitter/27-twitter.js
+++ b/social/twitter/27-twitter.js
@@ -642,7 +642,12 @@ module.exports = function(RED) {
                                     node.status({});
                                 } else {
                                     node.status({fill:"red",shape:"ring",text:"twitter.status.failed"});
-                                    node.error(result.body.errors[0].message,msg);
+                                    
+                                    if ('error' in result.body && typeof result.body.error === 'string') {
+                                        node.error(result.body.error,msg);
+                                    } else {
+                                        node.error(result.body.errors[0].message,msg);
+                                    }
                                 }
                             }).catch(function(err) {
                                 node.status({fill:"red",shape:"ring",text:"twitter.status.failed"});


### PR DESCRIPTION
Applications pending approval will return a different response body than what is presently supported if the developer tries to use this node before their developer account/keys have been approved for sending tweets.

Below is a copy of the actual response that comes back in this scenario:
```
{
  "status": 401,
  "rateLimitTimeout": null,
  "body": {
    "request": "/1.1/statuses/update.json",
    "error": "Read-only application cannot POST."
  }
}
```

Whereas the current implementation assumes the presence of an `errors` array, reading off the first element (i.e. `result.body.errors[0]`), the above scenario throws an exception as `result.body.errors` is now `undefined` and cannot be indexed).

The proposed update seeks to account for this while retaining existing functionality and has been tested (error message in debug now properly says "Read-only application cannot POST."

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
