### PR TITLE
Fix status error in mongoDB node

### DIFF
--- a/storage/mongodb/66-mongodb.js
+++ b/storage/mongodb/66-mongodb.js
@@ -69,7 +69,7 @@ module.exports = function(RED) {
         this.multi = n.multi || false;
         this.operation = n.operation;
         this.mongoConfig = RED.nodes.getNode(this.mongodb);
-        this.status({fill:"grey",shape:"ring",text:RED._("mongodbstatus.connecting")});
+        this.status({fill:"grey",shape:"ring",text:RED._("mongodb.status.connecting")});
         var node = this;
         var noerror = true;
 


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Because there is an error in the status of the MongoDB node as the following screenshot, I fixed it to refer to the message catalog correctly.
<img width="476" alt="mongodb" src="https://user-images.githubusercontent.com/20310935/97424861-ab7d6080-1954-11eb-82a9-5dca3d341422.png">

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
