### PR TITLE
When multiple keys are entered at the same time, the contents of payload become abnormal.

### DIFF
--- a/hardware/PiGpio/36-rpi-gpio.js
+++ b/hardware/PiGpio/36-rpi-gpio.js
@@ -276,11 +276,16 @@ module.exports = function(RED) {
             node.status({fill:"green",shape:"dot",text:"rpi-gpio.status.ok"});
 
             node.child.stdout.on('data', function (data) {
-                var b = data.toString().trim().split(",");
-                var act = "up";
-                if (b[1] === "1") { act = "down"; }
-                if (b[1] === "2") { act = "repeat"; }
-                node.send({ topic:"pi/key", payload:Number(b[0]), action:act });
+                var d = data.toString().trim().split("\n");
+                for (var i = 0; i < d.length; i++) {
+                    if (d[i] !== '') {
+                        var b = d[i].trim().split(",");
+                        var act = "up";
+                        if (b[1] === "1") { act = "down"; }
+                        if (b[1] === "2") { act = "repeat"; }
+                        node.send({ topic:"pi/key", payload:Number(b[0]), action:act });
+                    }
+                }
             });
 
             node.child.stderr.on('data', function (data) {


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes


Connect the "Pi Keyboard" node and the debug node and hit the two keys at the same time.
Then, the payload becomes an abnormal value as shown in the image.

The reason for the problem is that the PiKeyboardNode function does not support multi-line standard input.
I solved the problem by splitting the standard input, like the GPIOInNode function.

![node-red-problem](https://user-images.githubusercontent.com/23054570/99261338-e8f05200-285f-11eb-8bf0-450c61d1b626.png)

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
