### PR TITLE
Wemo insight power parameters

### DIFF
--- a/hardware/wemo/README.md
+++ b/hardware/wemo/README.md
@@ -73,16 +73,39 @@ And a lightbulb can look like this:
    }
 ```
 
-Insight
+An Insight socket output can look like this:
 
 ```
   {
     "raw": "<e:propertyset xmlns:e=\"urn:schemas-upnp-org:event-1-0\">\n<e:property>\n<BinaryState>8|1454271649|301|834|56717|1209600|8|1010|638602|12104165</BinaryState>\n</e:property>\n</e:propertyset>\n\n\r",
     "state": "8",
-    "power": 1.01,
+    "onSince": 1611179325,
+    "onFor": 2545,
+    "onToday": 17432,
+    "onTotal": 47939,
+    "averagePower": 13,
+    "power": 3.205,
+    "energyToday": 3596536,
+    "energyTotal": 9966151
     "sid": "uuid:ea808ecc-1dd1-11b2-9579-8e5c117d479e",
     "type": "socket",
     "name": "WeMo Insight",
     "id": "221450K1200F5C"
   }
 ```
+Some information about those power parameters:
++ `state`: Whether the device is currently ON or OFF (1 or 0).
++ `onSince`: The date and time when the device was last turned on or off (as a Unix timestamp).
++ `onFor`: How long the device was last ON for (seconds).
++ `onToday`: How long the device has been ON today (seconds).
++ `onTotal`: How long the device has been ON total (seconds).
++ `timespan`: Timespan over which onTotal is relevant (seconds). Typically 2 weeks except when first started up.
++ `averagePower`: Average power consumption (Watts).
++ `power`: Current power consumption (Watts).
++ `energyToday`: Energy used today (Watt-hours, or Wh).
++ `energyTotal`: Energy used in total (Wh).
++ `standbyLimit`: Minimum energy usage to register the insight as switched on ( milliwats, default 8000mW, configurable via WeMo App).
+
+## Lookup Node
+
+This node queries the current state of a device, when an input message is injected.  The output is very similar to that of the Input node.

--- a/hardware/wemo/WeMoNG.html
+++ b/hardware/wemo/WeMoNG.html
@@ -29,9 +29,26 @@
     <li>Light Groups</li>
     <li>Motion Detector</li>
   </ul>
-  <p>Sockets will generate msg.payload with values of 0/1/8 for off or on 
-  (8 is on but at standby load for insight sockets), lightswill return an
-  object like this:</p>
+  <p>Sockets will generate msg.payload with values of 0 or 1 (for off or on).</p> 
+  <p>Insight sockets will return an object like this (where state can also be 8 at standby):</p>
+  <pre>
+  {
+    state: "1"
+    onSince: 1611180205
+    onFor: 853
+    onToday: 18284
+    onTotal: 48785
+    averagePower: 12
+    power: 0
+    energyToday: 3772853
+    energyTotal: 10142468
+    sid: "uuid:adebe0c4-1dd1-11b2-8779-d6b6d5a8a932"
+    type: "socket"
+    name: "WeMo Insight"
+    id: "221536K12000B4"
+  }
+  </pre>
+  <p>Lights will return an object like this:</p>
   <pre>
   {
     name: 'Bedroom light',
@@ -164,7 +181,23 @@
 
 <script type="text/x-red" data-help-name="wemo lookup">
     <p>This node queries the current state of a device</p>
-    <p>For lights it return a msg.payload that looks like this:</p>
+    <p>For sockets it returns a msg.payload that looks like this:</p>
+<pre>{
+  state: 0
+}</pre>
+    <p>For insight sockets it returns a msg.payload that contains extra power parameters:</p>
+<pre>{
+  state: 0,
+  onSince: 1611179325,
+  onFor: 2545,
+  onToday: 17432,
+  onTotal: 47939,
+  averagePower: 13,
+  power: 3.205,
+  energyToday: 3596536,
+  energyTotal: 9966151
+}</pre>
+    <p>For lights it returns a msg.payload that looks like this:</p>
 <pre>{
   available: true,
   state: 0,

--- a/hardware/wemo/package.json
+++ b/hardware/wemo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-node-wemo",
-  "version": "0.1.19",
+  "version": "0.2.0",
   "description": "Input and Output nodes for Belkin WeMo devices",
   "repository": "https://github.com/node-red/node-red-nodes/tree/master/hardware",
   "main": "WeMoNG.js",

--- a/hardware/wemo/package.json
+++ b/hardware/wemo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-node-wemo",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Input and Output nodes for Belkin WeMo devices",
   "repository": "https://github.com/node-red/node-red-nodes/tree/master/hardware",
   "main": "WeMoNG.js",


### PR DESCRIPTION
Hey guys,

Here are my code changes to implement power parameters for Wemo Insight switches, based on [this](https://discourse.nodered.org/t/measure-the-power-consumption-via-a-wemo-insight-switch/39288/13?u=bartbutenaers) Discourse discussion.

Thanks for reviewing!
Bart

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Proposed changes

The output message of the Input-node and the Lookup-node now contains power parameters for the Wemo Insight devices:

+ `onSince`: The date and time when the device was last turned on or off (as a Unix timestamp).
+ `onFor`: How long the device was last ON for (seconds).
+ `onToday`: How long the device has been ON today (seconds).
+ `onTotal`: How long the device has been ON total (seconds).
+ `timespan`: Timespan over which onTotal is relevant (seconds). Typically 2 weeks except when first started up.
+ `averagePower`: Average power consumption (Watts).
+ `power`: Current power consumption (Watts).
+ `energyToday`: Energy used today (Watt-hours, or Wh).
+ `energyTotal`: Energy used in total (Wh).
+ `standbyLimit`: Minimum energy usage to register the insight as switched on ( milliwats, default 8000mW, configurable via WeMo App).

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
