### PR TITLE
Return all feed data

### DIFF
--- a/io/emoncms/88-emoncms.html
+++ b/io/emoncms/88-emoncms.html
@@ -83,7 +83,9 @@
 
 <script type="text/x-red" data-help-name="emoncms in">
     <p>Fetches data from emoncms.</p>
-    <p>The <code>msg.payload</code> contains last emoncms feed value
+    <p>The <code>msg.topic</code> contains the name of the Feed</p>
+    <p>The <code>msg.payload</code> contains last emoncms feed value</p>
+    <p>The <code>msg.feed_data</code> contains all the feed data</p>
 </script>
 
 <script type="text/javascript">

--- a/io/emoncms/88-emoncms.js
+++ b/io/emoncms/88-emoncms.js
@@ -160,7 +160,7 @@ module.exports = function(RED) {
         if (this.baseurl.substring(0,5) === "https") { http = require("https"); }
         else { http = require("http"); }
         this.on("input", function(msg) {
-            this.url = this.baseurl + '/feed/value.json';
+            this.url = this.baseurl + '/feed/aget.json';
             this.url += '&apikey='+this.apikey;
             var feedid = this.feedid || msg.feedid;
             if (feedid !== "") {
@@ -169,14 +169,17 @@ module.exports = function(RED) {
             http.get(this.url, function(res) {
                 msg.rc = res.statusCode;
                 msg.payload = "";
+                msg.feed_data = "";
                 res.setEncoding('utf8');
                 res.on('data', function(chunk) {
-                    msg.payload += chunk;
+                    msg.feed_data += chunk;
                 });
                 res.on('end', function() {
                     if (msg.rc === 200) {
                         try {
-                            msg.payload = JSON.parse(msg.payload);
+                            msg.feed_data = JSON.parse(msg.feed_data);
+                            msg.topic = msg.feed_data.name;
+                            msg.payload = msg.feed_data.value;
                         }
                         catch(err) {
                             // Failed to parse, pass it on


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
The `emoncms in` node simply returned the last feed value. This change retains that but also makes the richer set of feed data available on a separate part of the message. Feature request https://community.openenergymonitor.org/t/emonpi-not-communicating-with-emoncms/16641/6

Instead of the topic being returned blank, the Feed name is returned as the topic.

This is a non-breaking change.

No other refactoring has been attempted.

I do not know what `grunt` is. No unit test required.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [X] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
