### PR TITLE
Add IPv6 support to node

### DIFF
--- a/io/ping/88-ping.html
+++ b/io/ping/88-ping.html
@@ -5,6 +5,14 @@
         <input type="text" id="node-input-host" placeholder="192.168.0.1, www.google.com">
     </div>
     <div class="form-row">
+        <label for="node-protocol"><i class="fa fa-gear"></i> <span data-i18n="ping.label.protocol"></label>
+        <select type="text" id="node-input-protocol" style="width: 70%">
+            <option value="Automatic" data-i18n="ping.label.protocol_option.auto"></option>
+            <option value="IPv4" data-i18n="ping.label.protocol_option.ipv4"></option>
+            <option value="IPv6" data-i18n="ping.label.protocol_option.ipv6"></option>
+        </select>
+    </div>
+    <div class="form-row">
         <label for="node-input-mode"><i class="fa fa-wrench"></i> <span data-i18n="ping.label.mode"></label>
         <select type="text" id="node-input-mode" style="width: 70%">
             <option value="timed" data-i18n="ping.label.mode_option.timed"></option>
@@ -54,6 +62,7 @@ var timerParameterValidator = function(node,v){
         category: "network-input",
         color:"#fdf0c2",
         defaults: {
+            protocol: {value:"Automatic"},
             mode: {value:"timed"},
             name: {value:""},
             host: {value:"", validate: function(v){

--- a/io/ping/88-ping.js
+++ b/io/ping/88-ping.js
@@ -126,7 +126,7 @@ module.exports = function(RED) {
                 if (plat == "linux" || plat == "android") {
                     commandLineOptions = ["-n", "-w", timeoutS, "-c", "1"];
                 } else if (plat == "darwin" || plat == "freebsd") {
-                    commandLineOptions = ["-n", "-c", "1"] //NOTE: dont know if -X works on mac OSX
+                    commandLineOptions = ["-n", "-c", "1"] //NOTE: -X / timeout does not work on mac OSX and most freebsd systems
                 } else {
                     node.error("Sorry IPv6 on your platform - "+plat+" - is not supported.", msg);
                 }

--- a/io/ping/88-ping.js
+++ b/io/ping/88-ping.js
@@ -126,7 +126,7 @@ module.exports = function(RED) {
                 if (plat == "linux" || plat == "android") {
                     commandLineOptions = ["-n", "-w", timeoutS, "-c", "1"];
                 } else if (plat == "darwin" || plat == "freebsd") {
-                    commandLineOptions = ["-n", "-X", timeoutS, "-c", "1"] //NOTE: dont know if -X works on mac OSX
+                    commandLineOptions = ["-n", "-c", "1"] //NOTE: dont know if -X works on mac OSX
                 } else {
                     node.error("Sorry IPv6 on your platform - "+plat+" - is not supported.", msg);
                 }

--- a/io/ping/88-ping.js
+++ b/io/ping/88-ping.js
@@ -6,7 +6,7 @@ module.exports = function(RED) {
 
     function doPing(node, host, arrayMode) {
         const defTimeout = 5000;
-        var ex, hostOptions, commandLineOptions;
+        var ex, ex6, hostOptions, commandLineOptions;
         if (typeof host === "string") {
             hostOptions = {
                 host: host,
@@ -25,12 +25,33 @@ module.exports = function(RED) {
         if (arrayMode) {
             msg.ping = hostOptions
         }
+
+        //User Selected Protocol
         if (plat == "linux" || plat == "android") {
-            commandLineOptions = ["-n", "-w", timeoutS, "-c", "1"]
+            if (node.protocol === "IPv4") {
+                commandLineOptions = ["-n", "-4", "-w", timeoutS, "-c", "1"]; //IPv4
+            } else if (node.protocol === "IPv6") {
+                commandLineOptions = ["-n", "-6", "-w", timeoutS, "-c", "1"]; //IPv6
+            } else {
+              commandLineOptions = ["-n", "-w", timeoutS, "-c", "1"]; //Automatic
+            }
         } else if (plat.match(/^win/)) {
-            commandLineOptions = ["-n", "1", "-w", hostOptions.timeout]
+            if (node.protocol === "IPv4") {
+                commandLineOptions = ["-n", "1", "-4", "-w", hostOptions.timeout]; //IPv4
+            } else if (node.protocol === "IPv6") {
+                commandLineOptions = ["-n", "1", "-6", "-w", hostOptions.timeout]; //IPv6
+            } else {
+                commandLineOptions = ["-n", "1", "-w", hostOptions.timeout]; //Automatic
+            }
         } else if (plat == "darwin" || plat == "freebsd") {
-            commandLineOptions = ["-n", "-t", timeoutS, "-c", "1"]
+            if (node.protocol === "IPv4") {
+                commandLineOptions = ["-n", "-4", "-t", timeoutS, "-c", "1"]; //IPv4
+            } else if (node.protocol === "IPv6") {
+                commandLineOptions = ["-n", "-6", "-t", timeoutS, "-c", "1"]; //IPv6
+            } else {
+                commandLineOptions = ["-n", "-t", timeoutS, "-c", "1"]; //Automatic
+            }
+
         } else {
             node.error("Sorry - your platform - "+plat+" - is not recognised.", msg);
             return; //dont pass go - just return!
@@ -53,6 +74,23 @@ module.exports = function(RED) {
         var fail = false;
         //var regex = /from.*time.(.*)ms/;
         var regex = /=.*[<|=]([0-9]*).*TTL|ttl..*=([0-9\.]*)/;
+
+        var tryPing6 = false;
+        //catch error msg from ping
+        ex.stderr.setEncoding('utf8');
+        ex.stderr.on("data", function (data) {
+            if (!data.includes('Usage')) { // !data: only get the error and not how to use the ping command
+                if (data.includes('invalid') && data.includes('6')) { //if IPv6 not supported in version of ping try ping6
+                    tryPing6 = true;
+                    //node.error(data, msg); // used for testing output of -6 on ping command. Keep this line untill out of beta testing please.  Contact---> https://discourse.nodered.org/u/meeki007
+                } else if (data.includes('Network is unreachable')) {
+                    node.error(data + "  Please check that your service provider or network device has IPv6 enabled", msg);
+                } else {
+                    node.error(data, msg);
+                }
+            }
+        });
+
         ex.stdout.on("data", function (data) {
             line += data.toString();
         });
@@ -72,20 +110,88 @@ module.exports = function(RED) {
             }
         });
         ex.on("close", function (code) {
-            if (fail) { fail = false; return; }
-            var m = regex.exec(line)||"";
-            if (m !== "") {
-                if (m[1]) { res = Number(m[1]); }
-                if (m[2]) { res = Number(m[2]); }
+            if (tryPing6 === false) {
+                if (fail) { fail = false; return; }
+                var m = regex.exec(line)||"";
+                if (m !== "") {
+                    if (m[1]) { res = Number(m[1]); }
+                    if (m[2]) { res = Number(m[2]); }
+                }
+                if (code === 0) { msg.payload = res }
+                try { node.send(msg); }
+                catch(e) {console.warn(e)}
+
+            } else {
+                //fallback to ping6 for OS's that have not updated/out of date
+                if (plat == "linux" || plat == "android") {
+                    commandLineOptions = ["-n", "-w", timeoutS, "-c", "1"];
+                } else if (plat == "darwin" || plat == "freebsd") {
+                    commandLineOptions = ["-n", "-X", timeoutS, "-c", "1"] //NOTE: dont know if -X works on mac OSX
+                } else {
+                    node.error("Sorry IPv6 on your platform - "+plat+" - is not supported.", msg);
+                }
+                //spawn with timeout in case of os issue
+                ex6 = spawn("ping6", [...commandLineOptions, hostOptions.host]);
+
+                //monitor every spawned process & SIGINT if too long
+                var spawnTout = setTimeout(() => {
+                    node.log(`ping6 - Host '${hostOptions.host}' process timeout - sending SIGINT`)
+                    try {
+                        if (ex6 && ex6.pid) { ex6.kill("SIGINT"); }
+                    }
+                    catch(e) {console.warn(e); }
+                }, hostOptions.timeout+1000); //add 1s for grace
+
+                //catch error msg from ping6
+                ex6.stderr.setEncoding('utf8');
+                ex6.stderr.on("data", function (data) {
+                    if (!data.includes('Usage')) { // !data: only get the error and not how to use the ping6 command
+                        if (data.includes('Network is unreachable')) {
+                              node.error(data + "  Please check that your service provider or network device has IPv6 enabled", msg);
+                          } else {
+                              node.error(data, msg);
+                        }
+                    }
+                });
+
+                ex6.stdout.on("data", function (data) {
+                    line += data.toString();
+                });
+                ex6.on("exit", function (err) {
+                    clearTimeout(spawnTout);
+                });
+                ex6.on("error", function (err) {
+                    fail = true;
+                    if (err.code === "ENOENT") {
+                        node.error(err.code + " ping6 command not found", msg);
+                    }
+                    else if (err.code === "EACCES") {
+                        node.error(err.code + " can't run ping6 command", msg);
+                    }
+                    else {
+                        node.error(err.code, msg);
+                    }
+                });
+                ex6.on("close", function (code) {
+                    if (fail) { fail = false; return; }
+                    var m = regex.exec(line)||"";
+                    if (m !== "") {
+                        if (m[1]) { res = Number(m[1]); }
+                        if (m[2]) { res = Number(m[2]); }
+                    }
+                    if (code === 0) { msg.payload = res }
+                    try { node.send(msg); }
+                    catch(e) {console.warn(e)}
+                });
             }
-            if (code === 0) { msg.payload = res }
-            try { node.send(msg); }
-            catch(e) {console.warn(e)}
+
         });
+
     }
 
     function PingNode(n) {
         RED.nodes.createNode(this,n);
+        this.protocol = n.protocol||'Automatic';
         this.mode = n.mode;
         this.host = n.host;
         this.timer = n.timer * 1000;

--- a/io/ping/locales/en-US/88-ping.html
+++ b/io/ping/locales/en-US/88-ping.html
@@ -15,6 +15,19 @@
     <p>Returns <b>false</b> if no response received, or if the host is unresolveable.</p>
     <p>Default ping is every 20 seconds but can be configured.</p>
 
+    <h4>Protocol...</h4>
+    <ul>
+        <li><b>Automatic</b><br>
+            <P>Will use any Protocol, IPv4 or IPv6, to reach host; based on your operating system network settings</P>
+        </li>
+        <li><b>IPv4</b><br>
+            <P>Forces use of IPv4 to reach host. Will fail if no route availibe</P>
+        </li>
+        <li><b>IPv6</b><br>
+            <P>Forces use of IPv6 to reach host. Will fail if no route availibe</P>
+        </li>
+    </ul>
+
     <h4>Mode...</h4>
     <ul>
         <li><b>Timed</b><br>

--- a/io/ping/locales/en-US/88-ping.json
+++ b/io/ping/locales/en-US/88-ping.json
@@ -9,6 +9,12 @@
                 "timed": "Timed",
                 "triggered": "Triggered"
             },
+            "protocol": "Protocol",
+            "protocol_option": {
+                "auto": "Automatic",
+                "ipv4": "IPv4",
+                "ipv6": "IPv6"
+            },
             "tip": "Note: Leave Target field blank to allow msg.payload to set hosts dynamically."
         }
     }

--- a/io/ping/locales/ja/88-ping.html
+++ b/io/ping/locales/ja/88-ping.html
@@ -15,6 +15,19 @@
     <p>ホスト名が解決できなかったり、レスポンスが得られなければ、<b>false</b>を返します。</p>
     <p>デフォルトでは20秒ごとにpingを送りますが、設定で変更できます。</p>
 
+    <h4>Protocol...</h4>
+    <ul>
+        <li><b>Automatic</b><br>
+            <P>Will use any Protocol, IPv4 or IPv6, to reach host; based on your operating system network settings</P>
+        </li>
+        <li><b>IPv4</b><br>
+            <P>Forces use of IPv4 to reach host. Will fail if no route availibe</P>
+        </li>
+        <li><b>IPv6</b><br>
+            <P>Forces use of IPv6 to reach host. Will fail if no route availibe</P>
+        </li>
+    </ul>
+
     <h4>モード...</h4>
     <ul>
         <li><b>時間</b><br>
@@ -25,7 +38,7 @@
         <li><b>トリガー</b><br>
             <p><code>トリガー</code>モードでは、入力ワイヤを結線し、<code>msg</code>入力によってping処理を起動します。
     <p><code>ターゲット</code>フィールドに入力した値はホスト名もしくはIPアドレスとして使用します。 ターゲットはホスト名/IPアドレスをカンマで区切ったものです。例: <code>"192.168.0.1"</code> あるいは <code>"192.168.0.1, www.google.com"</code></p>
-    
+
             <p><code>ターゲット</code>を空にした場合、カンマ区切り文字列、もしくは、ホストの配列を<code>msg.payload</code>に指定します。
                 <ul>
                     <li><code>文字列</code> - カンマ区切りのホスト名/IPアドレス 例: <code>"192.168.0.1"</code> あるいは <code>"192.168.0.1, www.google.com"</code> </li>
@@ -33,12 +46,12 @@
                 <li>配列ペイロードの例: <pre>[
     "192.168.0.99",
     {
-        "host":"192.168.0.1", 
+        "host":"192.168.0.1",
         "name":"ルータ"
-    },  
+    },
     {
-        "host":"myapiserver.com", 
-        "name":"拡張API", 
+        "host":"myapiserver.com",
+        "name":"拡張API",
         "timeout": 20000,
         "support":"support@myapiserver.com"
     }

--- a/io/ping/locales/ja/88-ping.json
+++ b/io/ping/locales/ja/88-ping.json
@@ -9,6 +9,12 @@
                 "timed": "時間",
                 "triggered": "トリガー"
             },
+            "protocol": "プロトコル",
+            "protocol_option": {
+                "auto": "自動の",
+                "ipv4": "IPv4",
+                "ipv6": "IPv6"
+            },
             "tip": "注: msg.payloadでホスト名を動的に指定する場合は、ターゲットフィールドを空にします。"
         }
     }


### PR DESCRIPTION
- [X] New feature (non-breaking change which adds functionality)

Reff Thread ---> [https://discourse.nodered.org/t/node-red-node-ping-add-options-for-ipv4-ipv6-selection/41137](https://discourse.nodered.org/t/node-red-node-ping-add-options-for-ipv4-ipv6-selection/41137

Proposed changes
Add option to select IPv4 or IPv6 with Automatic as the default.

Checklist
- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [X] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [X] I have added suitable unit tests to cover the new/changed functionality  NOTE: need mac and win testing.
Tested on: 
unbuntu 20.04
node-red v.1.2.9
