### PR TITLE
Pushover: Added retry and expire setting for Prio 2 messages

### DIFF
--- a/social/pushover/57-pushover.html
+++ b/social/pushover/57-pushover.html
@@ -84,6 +84,8 @@
 	<p><code>msg.url_title</code>: to add a url title if not already set in the properties</p>
 	<p><code>msg.html</code>: set to true or 1 if message is HTML formatted, <i><a href="https://pushover.net/api#html" target="_new">see the supported tags</a></i></p>
 	<p><code>msg.sound</code>: set the notification sound, <i><a href="https://pushover.net/api#sounds" target="_new">see the available options</a></i></p>
+    <p><code>msg.retry</code>: set retry interval for Emergency priority (2) messages, <i><a href="https://pushover.net/api#priority" target="_new">see details</a></i></p>
+    <p><code>msg.expire</code>: set retry duration for Emergency priority (2) messages, <i><a href="https://pushover.net/api#priority" target="_new">see details</a></i></p>
     <p>Uses Pushover. See <i><a href="https://pushover.net" target="_new">this link</a></i> for more details.</p>
 </script>
 

--- a/social/pushover/57-pushover.js
+++ b/social/pushover/57-pushover.js
@@ -39,9 +39,27 @@ module.exports = function(RED) {
             var url_title = node.url_title || msg.url_title || null;
             var html = node.html || msg.html || false;
             var attachment = msg.attachment || null;
+            var retry = msg.retry || 30;
+            var expire = msg.expire || 600;
             if (isNaN(pri)) {pri=0;}
             if (pri > 2) {pri = 2;}
             if (pri < -2) {pri = -2;}
+			if (isNaN(retry)) {
+                retry = 30;
+                node.warn("No valid number for retry found, using default 30s retry interval");
+            }
+            if (isNaN(expire)) {
+                expire = 600;
+                node.warn("No valid number for expire time found, using default 600s retry duration");
+            }
+            if (retry < 30) {
+                retry = 30;
+                node.warn("Retry interval too low, using minimal 30s retry interval");
+            }
+            if (expire > 10800) {
+                expire = 10800;
+                node.warn("Expire time too high, using maximum setting of 10800s (3 hours) retry duration");
+            }
             if (typeof msg.payload === 'undefined') { msg.payload = "(undefined msg.payload)"; }
             if (typeof(msg.payload) === 'object') {
                 msg.payload = JSON.stringify(msg.payload);
@@ -52,8 +70,8 @@ module.exports = function(RED) {
                     message: msg.payload,
                     title: title,
                     priority: pri,
-                    retry: 30,
-                    expire: 600,
+                    retry: retry,
+                    expire: expire,
                     html: html
                 };
                 if (dev) { pushmsg.device = dev; }

--- a/social/pushover/README.md
+++ b/social/pushover/README.md
@@ -26,6 +26,8 @@ Optionally uses `msg.topic` to set the configuration, if not already set in the 
  - `msg.url_title`: to add a url title
  - `msg.html`: set to true or 1 if message is HTML formatted, see the [supported tags](https://pushover.net/api#html)
  - `msg.sound`: to set the alert sound, see the [available options](https://pushover.net/api#sounds)
+ - `msg.retry`: to set retry interval for Emergency priority (2) messages, see [priority](https://pushover.net/api#priority)
+ - `msg.expire`: to set retry duration for Emergency priority (2) messages, see [priority](https://pushover.net/api#priority)
 
 The User-key and API-token are stored in a separate credentials file.
 

--- a/social/pushover/package.json
+++ b/social/pushover/package.json
@@ -1,6 +1,6 @@
 {
     "name"          : "node-red-node-pushover",
-    "version"       : "0.0.23",
+    "version"       : "0.0.24",
     "description"   : "A Node-RED node to send alerts via Pushover",
     "dependencies"  : {
         "pushover-notifications"   : "^1.2.2"


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

You can now set the expire time and retry interval via `msg.retry` and `msg.expire` for Emergency Priority Messages (Prio 2).

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
