### PR TITLE
Add support for separate plaintext in outgoing mails

### DIFF
--- a/social/email/61-email.js
+++ b/social/email/61-email.js
@@ -119,7 +119,13 @@ module.exports = function(RED) {
                     else {
                         var payload = RED.util.ensureString(msg.payload);
                         sendopts.text = payload; // plaintext body
-                        if (/<[a-z][\s\S]*>/i.test(payload)) { sendopts.html = payload; } // html body
+                        if (/<[a-z][\s\S]*>/i.test(payload)) { 
+                            sendopts.html = payload; // html body
+                            if (msg.hasOwnProperty("plain")) {
+                                var plaintext = RED.util.ensureString(msg.plain);
+                                sendopts.text = plaintext; // plaintext body - specific plaintext version
+                            }
+                        }
                         if (msg.attachments && Array.isArray(msg.attachments)) {
                             sendopts.attachments = msg.attachments;
                             for (var a=0; a < sendopts.attachments.length; a++) {

--- a/social/email/61-email.js
+++ b/social/email/61-email.js
@@ -121,8 +121,8 @@ module.exports = function(RED) {
                         sendopts.text = payload; // plaintext body
                         if (/<[a-z][\s\S]*>/i.test(payload)) { 
                             sendopts.html = payload; // html body
-                            if (msg.hasOwnProperty("plain")) {
-                                var plaintext = RED.util.ensureString(msg.plain);
+                            if (msg.hasOwnProperty("plaintext")) {
+                                var plaintext = RED.util.ensureString(msg.plaintext);
                                 sendopts.text = plaintext; // plaintext body - specific plaintext version
                             }
                         }

--- a/social/email/locales/de/61-email.html
+++ b/social/email/locales/de/61-email.html
@@ -10,7 +10,9 @@
     <h3>Gmail-Benutzer</h3>
     <p>Beim Zugriff auf Gmail kann es nötig sein, entweder <a target="_new" href="https://support.google.com/mail/answer/185833?hl=de">ein App-Passwort</a> zu aktivieren oder den <a target="_new" href="https://support.google.com/accounts/answer/6010255?hl=de">Zugriff aufs Google-Konto durch weniger sichere Apps</a> über die Google-Konto-Einstellungen zu erlauben.</p>
     <h3>Details</h3>
-    <p>Die Nachricht in <code>msg.payload</code> kann als HTML formatiert sein.</p>
+    <p>Die Nachricht in <code>msg.payload</code> kann als HTML formatiert sein.
+      Ein separater, davon abweichender Plaintext kann in <code>msg.plain</code> angegeben werden. Ansonsten wird auch <code>msg.payload</code> verwendet.
+      <code>msg.plain</code> wird ignoriert, wenn <code>msg.payload</code> kein HTML enthält.</p>
     <p>Wenn <code>msg.payload</code> ein binärer Buffer ist, so wird sie in einen Nachrichten-Dateianhang (attachment) konvertiert.
        Der Dateiname sollte mittels <code>msg.filename</code> angegeben werden.
        Optional kann <code>msg.description</code> als Nachrichtentext hinzugefügt werden.</p>

--- a/social/email/locales/de/61-email.html
+++ b/social/email/locales/de/61-email.html
@@ -11,8 +11,8 @@
     <p>Beim Zugriff auf Gmail kann es nötig sein, entweder <a target="_new" href="https://support.google.com/mail/answer/185833?hl=de">ein App-Passwort</a> zu aktivieren oder den <a target="_new" href="https://support.google.com/accounts/answer/6010255?hl=de">Zugriff aufs Google-Konto durch weniger sichere Apps</a> über die Google-Konto-Einstellungen zu erlauben.</p>
     <h3>Details</h3>
     <p>Die Nachricht in <code>msg.payload</code> kann als HTML formatiert sein.
-      Ein separater, davon abweichender Plaintext kann in <code>msg.plain</code> angegeben werden. Ansonsten wird auch <code>msg.payload</code> verwendet.
-      <code>msg.plain</code> wird ignoriert, wenn <code>msg.payload</code> kein HTML enthält.</p>
+      Ein separater, davon abweichender Plaintext kann in <code>msg.plaintext</code> angegeben werden. Ansonsten wird auch <code>msg.payload</code> verwendet.
+      <code>msg.plaintext</code> wird ignoriert, wenn <code>msg.payload</code> kein HTML enthält.</p>
     <p>Wenn <code>msg.payload</code> ein binärer Buffer ist, so wird sie in einen Nachrichten-Dateianhang (attachment) konvertiert.
        Der Dateiname sollte mittels <code>msg.filename</code> angegeben werden.
        Optional kann <code>msg.description</code> als Nachrichtentext hinzugefügt werden.</p>

--- a/social/email/locales/en-US/61-email.html
+++ b/social/email/locales/en-US/61-email.html
@@ -10,7 +10,9 @@
     <p>If you are accessing Gmail you may need to either enable <a target="_new" href="https://support.google.com/mail/answer/185833?hl=en">an application password</a>,
     or enable <a target="_new" href="https://support.google.com/accounts/answer/6010255?hl=en">less secure access</a> via your Google account settings.</p>
     <h3>Details</h3>
-    <p>The payload can be html format.</p>
+    <p>The payload can be html format. You may supply a separate plaintext version using <code>msg.plain</code>. 
+    If you don't and <code>msg.payload</code> contains html, it will also be used for the plaintext. 
+    <code>msg.plain</code> will be ignored if <code>msg.payload</code> doesn't contain html.</p>
     <p>If the payload is a binary buffer then it will be converted to an attachment.
     The filename should be set using <code>msg.filename</code>. Optionally <code>msg.description</code> can be added for the body text.</p>
     <p>Alternatively you may provide <code>msg.attachments</code> which should contain an array of one or

--- a/social/email/locales/en-US/61-email.html
+++ b/social/email/locales/en-US/61-email.html
@@ -10,9 +10,9 @@
     <p>If you are accessing Gmail you may need to either enable <a target="_new" href="https://support.google.com/mail/answer/185833?hl=en">an application password</a>,
     or enable <a target="_new" href="https://support.google.com/accounts/answer/6010255?hl=en">less secure access</a> via your Google account settings.</p>
     <h3>Details</h3>
-    <p>The payload can be html format. You may supply a separate plaintext version using <code>msg.plain</code>. 
+    <p>The payload can be html format. You may supply a separate plaintext version using <code>msg.plaintext</code>. 
     If you don't and <code>msg.payload</code> contains html, it will also be used for the plaintext. 
-    <code>msg.plain</code> will be ignored if <code>msg.payload</code> doesn't contain html.</p>
+    <code>msg.plaintext</code> will be ignored if <code>msg.payload</code> doesn't contain html.</p>
     <p>If the payload is a binary buffer then it will be converted to an attachment.
     The filename should be set using <code>msg.filename</code>. Optionally <code>msg.description</code> can be added for the body text.</p>
     <p>Alternatively you may provide <code>msg.attachments</code> which should contain an array of one or


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

* add `msg.plaintext` to be read by the email-out node which replaces `msg.payload` as input for `sendopts.text` if - and only if - `msg.payload` contains html and `msg.plaintext` is set
* update help accordingly

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
