### PR TITLE
Updates on Twitter-In node: 1. Node now takes topic string input rath…

### DIFF
--- a/social/twitter/27-twitter.html
+++ b/social/twitter/27-twitter.html
@@ -96,6 +96,10 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
         <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
     </div>
+    <div class="form-row">
+        <label for="node-input-pollInterval"><i class="fa fa-clock"></i> <span  data-i18n="twitter.label.pollInterval"></span></label>
+        <input type="text" id="node-input-pollInterval" data-i18n="[placeholder]twitter.placeholder.pollInterval">
+    </div>
     <div class="form-tips"><span data-i18n="[html]twitter.tip"></span></div>
 </script>
 
@@ -108,7 +112,8 @@
             tags: {value:""},
             user: {value:"false",required:true},
             name: {value:""},
-            inputs: {value:0}
+            inputs: {value:0},
+            pollInterval: {value:60000}
         },
         inputs: 0,
         outputs: 1,
@@ -139,6 +144,7 @@
             var userph = this._("twitter.placeholder.user");
             var forlabel = this._("twitter.label.for");
             var forph = this._("twitter.placeholder.for");
+            var pollInterval = this._("twitter.placeholder.pollInterval")
             $("#node-input-user").change(function() {
                 var type = $("#node-input-user option:selected").val();
                 if (type == "user") {
@@ -156,7 +162,7 @@
             $("#node-input-user").change();
         },
         oneditsave: function() {
-            if ($('#node-input-tags').val() === '' && $("#node-input-user option:selected").val() === 'false') {
+            if ($('#node-input-tags').val() === ''/* && $("#node-input-user option:selected").val() === 'false'*/) {
                 this.inputs = 1;
             }
             else {

--- a/social/twitter/locales/en-US/27-twitter.json
+++ b/social/twitter/locales/en-US/27-twitter.json
@@ -16,11 +16,13 @@
             "copy-accessToken": "Create a new 'Access token & access token secret' and copy them",
             "access_key": "Access token",
             "access_secret": "Access token secret",
-            "enter-id": "Set your Twitter ID"
+            "enter-id": "Set your Twitter ID",
+            "pollInterval": "Poll Interval"
         },
         "placeholder": {
             "for": "comma-separated words, @ids, #tags",
-            "user": "comma-separated @twitter handles"
+            "user": "comma-separated @twitter handles",
+            "pollInterval": "Time in milliseconds, default 60000 (1 minute)"
         },
         "search": {
             "public": "all public tweets",


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

**Updates on Twitter-In node:**
1. Node now takes topic string input rather than hard-coded
2. "Sticky" followers: If new input string suggests updates in handles to follow, creates "sticky" new intervals - meaning previously followed handles are maintained, new ones added
3. Node now takes refresh time as an input value, previously hardcoded at 60s

**Other info:**
4. I didn't add unit test cases, as I couldn't get the unit test lib to work as expected - can do with some guidance
5. I intended to use the latest Twitter API v2 which has breaking changes, but till v1.1 is functioning, thought it's best to let it be. When Twitter announces sunsetting of v1.1, I would like to contribute to upgrading this library to support v2.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [NO ] I have run `grunt` to verify the unit tests pass
- [NO ] I have added suitable unit tests to cover the new/changed functionality
