### PR TITLE
dynamic database name

### DIFF
--- a/storage/mongodb/66-mongodb.html
+++ b/storage/mongodb/66-mongodb.html
@@ -51,7 +51,7 @@
             topology: {value: "direct", required: true},
             connectOptions: {value: "", required: false},
             port: {value: 27017, required: true},
-            db: {value: "", required: true},
+            db: {value: "", required: false},
             name: {value: ""}
         },
         credentials: {
@@ -74,10 +74,52 @@
     });
 </script>
 
+<script type="text/html" data-help-name="mongodb">
+    <p>Define a connection method to your MongoDB server instance.</p>
+    <p>There are 3 supported options:
+        <details><summary>Standard/direct</summary>
+            For databases that request connections in the form
+            <code>
+              mongodb://[username]:[password]@[hostname]:[port]/[dbname]
+            </code>
+            Most often used for local MongoDB instances (localhost:27017), and other stand-alone instances.
+        </details>
+        <details><summary>Standard/replicaset</summary>
+            For databases that request connections in the form
+            <code>
+            mongodb://[username]:[password]@[hostnameA]:[port],[hostnameB]:[port]/[dbname]?replicaSet=[replsetname]
+            </code>
+            Often used with <q>database as a service</q> offerings,
+            or on-premises instances that have been configured for availability and resilience
+        </details>
+        <details><summary>Clustered by DNS seedlist</summary>
+            For databases that request connections in the form
+            <code>
+            mongodb+srv://[username]:[password]@[clustername]/[dbname]?retryWrites=true&w=majority
+            </code>
+            A configuration of MongoDB instances that provide availability and performance
+            through replication and sharding, accessed through a cluster alias name, rather than
+            by specific host:port connections. This is the default for MongoDB instances in the
+            <a href="https://www.mongodb.com/cloud/atlas" target="_blank">Atlas cloud service</a>.
+        </details>
+      <p><strong>Connect options</strong> is where you add the optional parameters required by your MongoDB instance.
+        This might include:
+        <ul><li>w=majority</li><li>replicaSet=replset</li><li>authSource=admin</li></ul> and any other options appropriate -
+        full set available at <a href="https://docs.mongodb.com/manual/reference/connection-string/" target="_blank">
+        Connection String URI Format — MongoDB Manual</a>.
+      <p>If you are connecting to <a href="https://cloud.ibm.com/catalog/services/databases-for-mongodb-group" target="_blank">
+        IBM Databases for MongoDB</a>, as a replica-set, be sure to append <code>ssl=true&tlsAllowInvalidCertificates=true </code>
+        to the <strong>Connect options</strong>.
+</script>
+
 <script type="text/html" data-template-name="mongodb out">
     <div class="form-row">
         <label for="node-input-mongodb"><i class="fa fa-bookmark"></i> <span data-i18n="mongodb.label.server"></span></label>
         <input type="text" id="node-input-mongodb">
+    </div>
+    <div class="form-row">
+        <label for="node-input-db"><i class="fa fa-database"></i> <span data-i18n="mongodb.label.database"></span></label>
+        <input type="text" id="node-input-dbname">
     </div>
     <div class="form-row">
         <label for="node-input-collection"><i class="fa fa-briefcase"></i> <span data-i18n="mongodb.label.collection"></span></label>
@@ -114,8 +156,36 @@
     <div class="form-tips" id="node-warning" style="display: none"><span data-i18n="[html]mongodb.tip"></span></div>
 </script>
 
+<script type="text/html" data-help-name="mongodb out">
+    <p>A simple MongoDB output node. Can save, insert, update and remove objects from a chosen collection.</p>
+    <p>Save will update an existing object or insert a new object if one does not already exist.</p>
+    <p>Insert will insert a new object.</p>
+    <p>Save and insert either store <code>msg</code> or <code>msg.payload</code>.</p>
+    <p>Update will modify an existing object or objects. The query to select objects to update uses <code>msg.query</code>
+    and the update to the element uses <code>msg.payload</code>. If <code>msg.query._id</code> is
+    a valid mongo ObjectId string it will be converted to an ObjectId type.</p>
+    <p>Update can add a object if it does not exist or update multiple objects.</p>
+    <p>Remove will remove objects that match the query passed in on <code>msg.payload</code>. A blank query will delete
+    <i>all of the objects</i> in the collection.</p>
+    <p>You can either use the database given in mongodb config or provide a database name or a context variable where
+    the database name should be loaded from. Before getting the collection, database will be switched to the given.</p>
+    <p>You can either set the collection method in the node config or on <code>msg.collection</code>. Setting it in the
+    node will override <code>msg.collection</code>.</p>
+    <p>By default MongoDB creates an <i>_id</i> property as the primary key - so repeated injections of the
+    same <code>msg</code> will result in many database entries.</p>
+    <p>If this is NOT the desired behaviour - ie. you want repeated entries to overwrite, then you must set
+    the <code>msg._id</code> property to be a constant by the use of a previous function node.</p>
+    <p>This could be a unique constant or you could create one based on some other msg property.</p>
+    <p>Currently we do not limit or cap the collection size at all... this may well change.</p>
+</script>
+
 <script type="text/javascript">
     function oneditprepare() {
+        $("#node-input-dbname").typedInput({
+          default: this.dbnameType||'str',
+          types: ["str", "msg", "flow", "global"]
+        });
+
         $("#node-input-operation").change(function () {
             var id = $("#node-input-operation option:selected").val();
 
@@ -137,7 +207,11 @@
                 $("#node-warning").hide();
             }
         });
-    }
+    };
+
+    function oneditsave() {
+      this.dbnameType = $("#node-input-dbname").typedInput('type');
+    };
 
     RED.nodes.registerType('mongodb out', {
         category: 'storage-output',
@@ -145,6 +219,8 @@
         defaults: {
             mongodb: {type: "mongodb", required: true},
             name: {value: ""},
+            dbname: {value: "", required: false, validate: RED.validators.typedInput("dbnameType")},
+            dbnameType: {value: "str"},
             collection: {value: ""},
             payonly: {value: false},
             upsert: {value: false},
@@ -162,14 +238,20 @@
         labelStyle: function() {
             return this.name ? "node_label_italic" : "";
         },
-        oneditprepare: oneditprepare
+        oneditprepare: oneditprepare,
+        oneditsave: oneditsave
     });
 </script>
+
 
 <script type="text/html" data-template-name="mongodb in">
     <div class="form-row">
         <label for="node-input-mongodb"><i class="fa fa-bookmark"></i> <span data-i18n="mongodb.label.server"></span></label>
         <input type="text" id="node-input-mongodb">
+    </div>
+    <div class="form-row">
+        <label for="node-input-db"><i class="fa fa-database"></i> <span data-i18n="mongodb.label.database"></span></label>
+        <input type="text" id="node-input-dbname">
     </div>
     <div class="form-row">
         <label for="node-input-collection"><i class="fa fa-briefcase"></i> <span data-i18n="mongodb.label.collection"></span></label>
@@ -190,6 +272,23 @@
     <div class="form-tips" id="node-warning" style="display: none"><span data-i18n="[html]mongodb.tip"></span></div>
 </script>
 
+<script type="text/html" data-help-name="mongodb in">
+    <p>Calls a MongoDB collection method based on the selected operator.</p>
+    <p>Find queries a collection using the <code>msg.payload</code> as the query statement as per the .find() function.
+    Optionally, you may also (via a function) set a <code>msg.projection</code> object to constrain the returned
+    fields, a <code>msg.sort</code> object, a <code>msg.limit</code> number and a <code>msg.skip</code> number.</p>
+    <p>Count returns a count of the number of documents in a collection or matching a query using the
+    <code>msg.payload</code> as the query statement.</p>
+    <p>Aggregate provides access to the aggregation pipeline using the <code>msg.payload</code> as the pipeline array.</p>
+    <p>You can either use the database given in mongodb config or provide a database name or a context variable where
+    the database name should be loaded from. Before getting the collection, database will be switched to the given.</p>
+    <p>You can either set the collection method in the node config or on <code>msg.collection</code>. Setting it in
+    the node will override <code>msg.collection</code>.</p>
+    <p>See the <a href="http://docs.mongodb.org/manual/reference/method/db.collection.find/" target="new"><i>MongoDB
+    collection methods docs</i></a> for examples.</p>
+    <p>The result is returned in <code>msg.payload</code>.</p>
+</script>
+
 <script type="text/javascript">
     RED.nodes.registerType('mongodb in', {
         category: 'storage-input',
@@ -197,6 +296,8 @@
         defaults: {
             mongodb: {type: "mongodb", required: true},
             name: {value: ""},
+            dbname: {value: "", required: false, validate: RED.validators.typedInput("dbnameType")},
+            dbnameType: {value: "str"},
             collection: {value: ""},
             operation: {value: "find"}
         },
@@ -210,6 +311,7 @@
         labelStyle: function() {
             return this.name ? "node_label_italic" : "";
         },
-        oneditprepare: oneditprepare
+        oneditprepare: oneditprepare,
+        oneditsave: oneditsave
     });
 </script>

--- a/storage/mongodb/package.json
+++ b/storage/mongodb/package.json
@@ -1,27 +1,27 @@
 {
-    "name"          : "node-red-node-mongodb",
-    "version"       : "0.2.5",
-    "description"   : "Node-RED nodes to talk to a Mongo database",
-    "dependencies"  : {
-        "mongodb"   : "^3.6.3"
-    },
-    "repository" : {
-        "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/storage/mongodb"
-    },
-    "license": "Apache-2.0",
-    "keywords": [ "node-red", "mongodb" ],
-    "node-red"      : {
-        "nodes"     : {
-            "mongo": "66-mongodb.js"
-        }
-    },
-    "author": {
-        "name": "Dave Conway-Jones",
-        "email": "ceejay@vnet.ibm.com",
-        "url": "http://nodered.org"
-    },
-    "contributors": [
+  "name": "node-red-node-mongodb",
+  "version": "0.2.6",
+  "description": "Node-RED nodes to talk to a Mongo database",
+  "dependencies": {
+    "mongodb": "^3.6.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/node-red/node-red-nodes/tree/master/storage/mongodb"
+  },
+  "license": "Apache-2.0",
+  "keywords": [ "node-red", "mongodb" ],
+  "node-red": {
+    "nodes": {
+      "mongo": "66-mongodb.js"
+    }
+  },
+  "author": {
+    "name": "Dave Conway-Jones",
+    "email": "ceejay@vnet.ibm.com",
+    "url": "http://nodered.org"
+  },
+  "contributors": [
     {
       "name": "Ross Cruickshank",
       "email": "ross@vnet.ibm.com"


### PR DESCRIPTION
Feature: database name can be dynamicaly provided as string oder context variable on "mongo in" and "mongo out"

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
missing feature to provide database name optionaly as context variable for example to use req.headers.host (without port) as database name. With that you can use same application with diferent data backends definded by query parameter, post data or in my case with domain name.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
