### PR TITLE
Added to wol node: num_packets and interval options

### DIFF
--- a/io/wol/39-wol.html
+++ b/io/wol/39-wol.html
@@ -17,7 +17,7 @@
         <input type="number" id="node-input-numpackets" placeholder="3">
     </div>
     <div class="form-row">
-        <label for="node-input-interval" style="width:120px;"><i class="fa fa-random"></i> Interval Between Pacets (ms)</label>
+        <label for="node-input-interval" style="width:120px;"><i class="fa fa-random"></i> Interval Between Packets (ms)</label>
         <input type="number" id="node-input-interval" placeholder="100">
     </div>
     <div class="form-row">

--- a/io/wol/39-wol.html
+++ b/io/wol/39-wol.html
@@ -13,11 +13,11 @@
         <input type="number" id="node-input-udpport" placeholder="9">
     </div>
     <div class="form-row">
-        <label for="node-input-numpackets" style="width:120px;"><i class="fa fa-random"></i> Number of Packets</label>
+        <label for="node-input-numpackets" style="width:120px;"><i class="fa fa-envelope"></i> Number of Packets</label>
         <input type="number" id="node-input-numpackets" placeholder="3">
     </div>
     <div class="form-row">
-        <label for="node-input-interval" style="width:120px;"><i class="fa fa-random"></i> Interval Between Packets (ms)</label>
+        <label for="node-input-interval" style="width:120px;"><i class="fa fa-clock-o"></i> Interval Between Packets (ms)</label>
         <input type="number" id="node-input-interval" placeholder="100">
     </div>
     <div class="form-row">

--- a/io/wol/39-wol.html
+++ b/io/wol/39-wol.html
@@ -13,6 +13,14 @@
         <input type="number" id="node-input-udpport" placeholder="9">
     </div>
     <div class="form-row">
+        <label for="node-input-num-packets" style="width:120px;"><i class="fa fa-random"></i> Number of Pacets</label>
+        <input type="number" id="node-input-num-packets" placeholder="3">
+    </div>
+    <div class="form-row">
+        <label for="node-input-interval" style="width:120px;"><i class="fa fa-random"></i> Interval Between Pacets (ms)</label>
+        <input type="number" id="node-input-interval" placeholder="100">
+    </div>
+    <div class="form-row">
         <label for="node-input-name" style="width:120px;"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>

--- a/io/wol/39-wol.html
+++ b/io/wol/39-wol.html
@@ -31,10 +31,10 @@
     <p>Sends a Wake-On-LAN magic packet to the mac address specified.</p>
     <p>You may instead set <code>msg.mac</code> to dynamically set the target device mac to wake up.</p>
     <p>The address of the target machine can optionally be set using <code>msg.host</code></p>
-    <p>You can likewise set the destination UDP port using <code>msg.udpport</code></p>
+    <p>You can likewise set the destination UDP port, number of packets sent, and interval between packets using <code>msg.udpport</code>, <code>msg.numpackets</code>, <code>msg.interval</code>.</p>
     <p>Setting the target address to the broadcast address of the subnet that the target machine is attached to works best.
     For a class C address this is usually just the first three parts of the ip address followed by 255. eg 192.168.1.255.</p>
-    <p>You can specify the target UDP port, default is 9.</p>
+    <p>You can specify the target UDP port (default 9), number of packets sent (default 3), and interval between packets (default 100ms).</p>
 </script>
 
 <script type="text/javascript">
@@ -45,8 +45,8 @@
             mac: {value:""},
             host: {value:""},
             udpport: {value:9, validate:RED.validators.number()},
-            numpackets: {value:3, validate:RED.validators.number()},
-            interval: {value:100, validate:RED.validators.number()},
+            numpackets: {value:3},
+            interval: {value:100},
             name: {value:""}
         },
         inputs:1,

--- a/io/wol/39-wol.html
+++ b/io/wol/39-wol.html
@@ -13,8 +13,8 @@
         <input type="number" id="node-input-udpport" placeholder="9">
     </div>
     <div class="form-row">
-        <label for="node-input-num-packets" style="width:120px;"><i class="fa fa-random"></i> Number of Pacets</label>
-        <input type="number" id="node-input-num-packets" placeholder="3">
+        <label for="node-input-numpackets" style="width:120px;"><i class="fa fa-random"></i> Number of Packets</label>
+        <input type="number" id="node-input-numpackets" placeholder="3">
     </div>
     <div class="form-row">
         <label for="node-input-interval" style="width:120px;"><i class="fa fa-random"></i> Interval Between Pacets (ms)</label>

--- a/io/wol/39-wol.html
+++ b/io/wol/39-wol.html
@@ -45,6 +45,8 @@
             mac: {value:""},
             host: {value:""},
             udpport: {value:9, validate:RED.validators.number()},
+            numpackets: {value:3, validate:RED.validators.number()},
+            interval: {value:100, validate:RED.validators.number()},
             name: {value:""}
         },
         inputs:1,

--- a/io/wol/39-wol.js
+++ b/io/wol/39-wol.js
@@ -22,7 +22,15 @@ module.exports = function(RED) {
             if (udpport < 1 || udpport > 65535) {
                 node.warn("WOL: UDP port must be within 1 and 65535; it has been reset to 9.");
                 udpport = 9;
-            }            
+            }
+            if (numpackets < 1 || numpackets > Number.MAX_SAFE_INTEGER) {
+                node.warn("WOL: Number of packets must be within 1 and $(Number.MAX_SAFE_INTEGER); it has been reset to 3.");
+                interval = 3;
+            }
+            if (interval < 1 || interval > Number.MAX_SAFE_INTEGER) {
+                node.warn("WOL: Interval between packets must be within 1 and $(Number.MAX_SAFE_INTEGER); it has been reset to 100.");
+                interval = 100;
+            }
             if (mac != null) {
                 if (chk.test(mac)) {
                     try {

--- a/io/wol/39-wol.js
+++ b/io/wol/39-wol.js
@@ -9,12 +9,16 @@ module.exports = function(RED) {
         this.mac = n.mac.trim();
         this.host = n.host;
         this.udpport = n.udpport;
+        this.numpackets = n.numpackets;
+        this.interval = n.interval;
         var node = this;
 
         this.on("input", function(msg) {
             var mac = this.mac || msg.mac || null;
             var host = this.host || msg.host || '255.255.255.255';
             var udpport = Number(msg.udpport || this.udpport || '9');
+            var numpackets = Number(msg.numpackets || this.numpackets || '3');
+            var interval = Number(msg.interval || this.interval || '100');
             if (udpport < 1 || udpport > 65535) {
                 node.warn("WOL: UDP port must be within 1 and 65535; it has been reset to 9.");
                 udpport = 9;
@@ -22,7 +26,7 @@ module.exports = function(RED) {
             if (mac != null) {
                 if (chk.test(mac)) {
                     try {
-                        wol.wake(mac, {address: host, port: udpport}, function(error) {
+                        wol.wake(mac, {address: host, port: udpport, num_packets: numpackets, interval: interval}, function(error) {
                             if (error) {
                                 node.warn(error);
                                 node.status({fill:"red",shape:"ring",text:" "});

--- a/io/wol/39-wol.js
+++ b/io/wol/39-wol.js
@@ -23,12 +23,12 @@ module.exports = function(RED) {
                 node.warn("WOL: UDP port must be within 1 and 65535; it has been reset to 9.");
                 udpport = 9;
             }
-            if (numpackets < 1 || numpackets > Number.MAX_SAFE_INTEGER) {
-                node.warn("WOL: Number of packets must be within 1 and $(Number.MAX_SAFE_INTEGER); it has been reset to 3.");
-                interval = 3;
+            if (numpackets < 1 || numpackets > 500) {
+                node.warn("WOL: Number of packets must be within 1 and 500; it has been reset to 3.");
+                numpackets = 3;
             }
-            if (interval < 1 || interval > Number.MAX_SAFE_INTEGER) {
-                node.warn("WOL: Interval between packets must be within 1 and $(Number.MAX_SAFE_INTEGER); it has been reset to 100.");
+            if (interval < 1 || interval > 3600000) {
+                node.warn("WOL: Interval between packets must be within 1 and 3600000; it has been reset to 100.");
                 interval = 100;
             }
             if (mac != null) {

--- a/io/wol/package.json
+++ b/io/wol/package.json
@@ -1,6 +1,6 @@
 {
     "name"          : "node-red-node-wol",
-    "version"       : "0.1.0",
+    "version"       : "0.2.0",
     "description"   : "A Node-RED node to send Wake-On-LAN (WOL) magic packets",
     "dependencies"  : {
         "wake_on_lan"   : "1.0.0"


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply


- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Similar to #606 - this PR is adding additional configuration options to the `wake` command. Number of packets and interval between packets are added as optional fields, will revert to wake_on_lan package defaults if left blank. 

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
