### PR TITLE
Node-red-node-twitter retweet support

### DIFF
--- a/social/twitter/README.md
+++ b/social/twitter/README.md
@@ -59,3 +59,9 @@ To send a Direct Message (DM) - use a payload like.
 If `msg.media` exists and is a Buffer object, this node will treat it as an image and attach it to the tweet.
 
 If `msg.params` exists and is an object of name:value pairs, this node will treat it as parameters for the update request.
+
+#### Retweet
+
+To retweet an existing tweet, set `msg.retweet` to the tweet id. The tweet id can be found in the `id_str` field of the tweet object.
+
+Before retweeting, make sure the tweet is not a retweet itself.


### PR DESCRIPTION
Fixes #834

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

See #834. The `retweet` endpoint is different from the `update` endpoint, and I added it to the output node.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team:  
 **No answers [in the forum](https://discourse.nodered.org/t/node-red-node-twitter-retweet-support/50038?u=baruchiro), but we discussed on #834**.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality:  
 **Unfortunately, there are no tests for Twitter Nodes**.
