### PR TITLE
Update package.jsons for mono-repo

### DIFF
--- a/analysis/mlsentiment/package.json
+++ b/analysis/mlsentiment/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/analysis/sentiment"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory" : "tree/master/analysis/mlsentiment"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "sentiment", "anaylsis", "AFINN" ],

--- a/analysis/sentiment/package.json
+++ b/analysis/sentiment/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/analysis/sentiment"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory" : "tree/master/analysis/sentiment"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "sentiment", "anaylsis", "AFINN" ],

--- a/analysis/swearfilter/package.json
+++ b/analysis/swearfilter/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/analysis/swearfilter"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/analysis/swearfilter"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "badwords", "swearfilter" ],

--- a/analysis/wordpos/package.json
+++ b/analysis/wordpos/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/analysis/wordpos"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory" : "tree/master/analysis/wordpos"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "wordpos" ],

--- a/function/PID/package.json
+++ b/function/PID/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/function/PID"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/function/PID"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "PID", "control" ],

--- a/function/datagenerator/package.json
+++ b/function/datagenerator/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/function/data-generator"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/function/data-generator"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "data-generator", "dummy-json" ],

--- a/function/random/package.json
+++ b/function/random/package.json
@@ -6,7 +6,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/function/random"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/function/random"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "random" ],

--- a/function/rbe/package.json
+++ b/function/rbe/package.json
@@ -6,7 +6,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/function/rbe"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/function/rbe"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "rbe", "bandgap", "deadband" ],

--- a/function/smooth/package.json
+++ b/function/smooth/package.json
@@ -6,7 +6,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/function/smooth"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/function/smooth"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "smooth", "average", "standard deviation" ],

--- a/hardware/Arduino/package.json
+++ b/hardware/Arduino/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/hardware/Arduino"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/hardware/Arduino"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "arduino", "firmata" ],

--- a/hardware/BBB/package.json
+++ b/hardware/BBB/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/hardware/BBB"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/hardware/BBB"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "beagleboneblack", "beaglebone", "bbb", "octalbonescript" ],

--- a/hardware/HummingboardGPIO/package.json
+++ b/hardware/HummingboardGPIO/package.json
@@ -6,7 +6,8 @@
     },
     "repository" : {
         "type":"tgz",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/hardware/HummingboardGPIO"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/hardware/HummingboardGPIO"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "hummingboard", "gpio" ],

--- a/hardware/LEDborg/package.json
+++ b/hardware/LEDborg/package.json
@@ -6,7 +6,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/hardware/ledborg"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory" : "tree/master/hardware/ledborg"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "ledborg" ],

--- a/hardware/PiFace/package.json
+++ b/hardware/PiFace/package.json
@@ -6,7 +6,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/hardware/PiFace"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/hardware/PiFace"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "piface" ],

--- a/hardware/PiGpio/package.json
+++ b/hardware/PiGpio/package.json
@@ -9,7 +9,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/node-red/node-red-nodes/tree/master/hardware/PiGpio"
+    "url": "https://github.com/node-red/node-red-nodes.git",
+    "directory": "tree/master/hardware/PiGpio"
   },
   "keywords": [
     "node-red", "Pi", "GPIO", "PiGpio"

--- a/hardware/PiLcd/package.json
+++ b/hardware/PiLcd/package.json
@@ -6,7 +6,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/hardware/PiLcd"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/hardware/PiLcd"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "lcd", "HD44780" ],

--- a/hardware/PiLiter/package.json
+++ b/hardware/PiLiter/package.json
@@ -6,7 +6,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/hardware/PiLiter"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/hardware/PiLiter"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "piliter" ],

--- a/hardware/PiSrf/package.json
+++ b/hardware/PiSrf/package.json
@@ -6,7 +6,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/hardware/PiSrf"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/hardware/PiSrf"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "SRF04", "SRF05", "ultrasonic", "range", "HC-SR04", "SR04" ],

--- a/hardware/Pibrella/package.json
+++ b/hardware/Pibrella/package.json
@@ -6,7 +6,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/hardware/Pibrella"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/hardware/Pibrella"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "pibrella" ],

--- a/hardware/blink1/package.json
+++ b/hardware/blink1/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/hardware/blink1"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory" : "tree/master/hardware/blink1"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "blink1" ],

--- a/hardware/blinkstick/package.json
+++ b/hardware/blinkstick/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/hardware/blinkstick"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/hardware/blinkstick"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "blinkstick" ],

--- a/hardware/digiRGB/package.json
+++ b/hardware/digiRGB/package.json
@@ -8,7 +8,8 @@
     "homepage": "http://www.hardill.me.uk/wordpress/2013/02/06/budget-blink1/",
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/hardware/digiRGB"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/hardware/digiRGB"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "digiRGB" ],

--- a/hardware/heatmiser/package.json
+++ b/hardware/heatmiser/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/io/heatmiser"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/io/heatmiser"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "heatmiser"],

--- a/hardware/intel/package.json
+++ b/hardware/intel/package.json
@@ -6,7 +6,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/hardware/intel"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory" : "tree/master/hardware/intel"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "intel", "galileo", "edison" ],

--- a/hardware/makey/package.json
+++ b/hardware/makey/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/hardware/makey"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/hardware/makey"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "makeymakey" ],

--- a/hardware/mcp3008/package.json
+++ b/hardware/mcp3008/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/hardware/mcp3008"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/hardware/mcp3008"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "pi", "adc", "mcp", "a/d converter" ],

--- a/hardware/neopixel/package.json
+++ b/hardware/neopixel/package.json
@@ -6,7 +6,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/hardware/neopixel"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/hardware/neopixel"
     },
     "license": "Apache-2.0",
     "keywords": [

--- a/hardware/physical-web/package.json
+++ b/hardware/physical-web/package.json
@@ -20,7 +20,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/node-red/node-red-nodes/tree/master/hardware/physical-web"
+    "url": "https://github.com/node-red/node-red-nodes.git",
+    "directory": "tree/master/hardware/physical-web"
   },
   "author": {
     "name": "Ben Hardill",

--- a/hardware/pigpiod/package.json
+++ b/hardware/pigpiod/package.json
@@ -10,7 +10,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/node-red/node-red-nodes/tree/master/hardware/pigpiod"
+    "url": "https://github.com/node-red/node-red-nodes.git",
+    "directory" : "tree/master/hardware/pigpiod"
   },
   "keywords": [
     "node-red", "Pi", "GPIO", "PiGPIOd"

--- a/hardware/sensehat/package.json
+++ b/hardware/sensehat/package.json
@@ -4,7 +4,8 @@
     "description"   : "A Node-RED node to interact with a Raspberry Pi Sense HAT",
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/hardware/sensehat"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/hardware/sensehat"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "sensehat", "astropi" ],

--- a/hardware/sensehatsim/package.json
+++ b/hardware/sensehatsim/package.json
@@ -4,7 +4,8 @@
     "description": "A Node-RED node to simulate a Raspberry Pi Sense HAT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/node-red/node-red-nodes/tree/master/hardware/sensehatsim"
+        "url": "https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/hardware/sensehatsim"
     },
     "dependencies": {
         "ws": "~6.2.1"

--- a/hardware/sensorTag/package.json
+++ b/hardware/sensorTag/package.json
@@ -17,7 +17,8 @@
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
-        "url": "https://github.com/node-red/node-red-nodes/tree/master/hardware/sensorTag"
+        "url": "https://github.com/node-red/node-red-nodes.git",
+        "directory" : "tree/master/hardware/sensorTag"
     },
     "node-red": {
         "nodes": {

--- a/hardware/unicorn/package.json
+++ b/hardware/unicorn/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/hardware/unicorn"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/hardware/unicorn"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "unicorn", "pimorini" ],

--- a/hardware/wemo/package.json
+++ b/hardware/wemo/package.json
@@ -2,7 +2,11 @@
   "name": "node-red-node-wemo",
   "version": "0.2.1",
   "description": "Input and Output nodes for Belkin WeMo devices",
-  "repository": "https://github.com/node-red/node-red-nodes/tree/master/hardware",
+  "repository" : {
+    "type":"git",
+    "url":"https://github.com/node-red/node-red-nodes.git",
+    "directory": "tree/master/hardware/wemo"
+},
   "main": "WeMoNG.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/io/emoncms/package.json
+++ b/io/emoncms/package.json
@@ -6,7 +6,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/io/emoncms"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory" : "tree/master/io/emoncms"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "emoncms" ],

--- a/io/mdns/package.json
+++ b/io/mdns/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/io/mdns"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/io/mdns"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "mdns", "avahi", "bonjour", "discovery" ],

--- a/io/mqlight/package.json
+++ b/io/mqlight/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/io/mqlight"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/io/mqlight"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "mqlight" ],

--- a/io/ping/package.json
+++ b/io/ping/package.json
@@ -6,7 +6,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/io/ping"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/io/ping"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "ping", "keepalive" ],

--- a/io/serialport/package.json
+++ b/io/serialport/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/io/serialport"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/io/serialport"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "serial" ],

--- a/io/snmp/package.json
+++ b/io/snmp/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/io/snmp"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory" : "tree/master/io/snmp"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "snmp", "oid" ],

--- a/io/stomp/package.json
+++ b/io/stomp/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/io/stomp"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/io/stomp"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "stomp", "stomp-client" ],

--- a/io/wol/package.json
+++ b/io/wol/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/io/wol"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory" : "tree/master/io/wol"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "wol", "wake_on_lan" ],

--- a/parsers/base64/package.json
+++ b/parsers/base64/package.json
@@ -7,7 +7,7 @@
     "repository" : {
         "type":"git",
         "url":"https://github.com/node-red/node-red-nodes.git",
-        "path": "/tree/master/parsers/base64"
+        "directory": "/tree/master/parsers/base64"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "base64" ],

--- a/parsers/geohash/package.json
+++ b/parsers/geohash/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/parsers/geohash"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/parsers/geohash"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "geohash" ],

--- a/parsers/markdown/package.json
+++ b/parsers/markdown/package.json
@@ -7,7 +7,8 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/node-red/node-red-nodes/tree/master/parsers/markdown"
+        "url": "https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/parsers/markdown"
     },
     "license": "Apache-2.0",
     "keywords": [

--- a/parsers/msgpack/package.json
+++ b/parsers/msgpack/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/parsers/msgpack"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/parsers/msgpack"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "msgpack" ],

--- a/parsers/smaz/package.json
+++ b/parsers/smaz/package.json
@@ -6,7 +6,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/parsers/smaz"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/parsers/smaz"
     },
     "license": "Apache-2.0",
     "keywords": [ "smaz" ],

--- a/parsers/what3words/package.json
+++ b/parsers/what3words/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/parsers/what3words"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/parsers/what3words"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "what3words" ],

--- a/social/dweetio/package.json
+++ b/social/dweetio/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/social/dweetio"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/social/dweetio"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "dweetio" ],

--- a/social/email/package.json
+++ b/social/email/package.json
@@ -18,7 +18,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/node-red/node-red-nodes/tree/master/social/email"
+    "url": "https://github.com/node-red/node-red-nodes.git",
+    "directory": "tree/master/social/email"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/social/feedparser/package.json
+++ b/social/feedparser/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/node-red/node-red-nodes/tree/master/social/feedparser"
+    "url": "https://github.com/node-red/node-red-nodes.git",
+    "directory": "tree/master/social/feedparser"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/social/irc/package.json
+++ b/social/irc/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/social/irc"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/social/irc"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "irc" ],

--- a/social/nma/package.json
+++ b/social/nma/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/social/nma"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory" : "tree/master/social/nma"
     },
     "license": "Apache-2.0",
     "keywords": [ "nma", "notify my android" ],

--- a/social/notify/package.json
+++ b/social/notify/package.json
@@ -8,7 +8,7 @@
     "repository" : {
         "type":"git",
         "url":"https://github.com/node-red/node-red-nodes.git",
-        "path":"/tree/master/social/notify"
+        "directory":"/tree/master/social/notify"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "notify", "growl"],

--- a/social/prowl/package.json
+++ b/social/prowl/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/social/prowl"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/social/prowl"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "prowl"],

--- a/social/pushbullet/package.json
+++ b/social/pushbullet/package.json
@@ -8,7 +8,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/social/pushbullet"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/social/pushbullet"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "pushbullet" ],

--- a/social/pusher/package.json
+++ b/social/pusher/package.json
@@ -8,7 +8,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/social/pusher"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/social/pusher"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "pusher" ],

--- a/social/pushover/package.json
+++ b/social/pushover/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/social/pushover"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/social/pushover"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "pushover" ],

--- a/social/twilio/package.json
+++ b/social/twilio/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/social/twilio"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/social/twilio"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "twilio", "sms" ],

--- a/social/twitter/package.json
+++ b/social/twitter/package.json
@@ -8,7 +8,8 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/node-red/node-red-nodes/tree/master/social/twitter"
+        "url": "https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/social/twitter"
     },
     "license": "Apache-2.0",
     "keywords": [

--- a/social/xmpp/package.json
+++ b/social/xmpp/package.json
@@ -10,7 +10,8 @@
     ],
     "repository": {
         "type": "git",
-        "url": "https://github.com/node-red/node-red-nodes/tree/master/social/xmpp"
+        "url": "https://github.com/node-red/node-red-nodes.git",
+        "directory" : "tree/master/social/xmpp"
     },
     "license": "Apache-2.0",
     "keywords": [

--- a/storage/leveldb/package.json
+++ b/storage/leveldb/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/storage/leveldb"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory":"tree/master/storage/leveldb"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "leveldb" ],

--- a/storage/mongodb/package.json
+++ b/storage/mongodb/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/storage/mongodb"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/storage/mongodb"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "mongodb" ],

--- a/storage/mysql/package.json
+++ b/storage/mysql/package.json
@@ -7,7 +7,8 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/node-red/node-red-nodes/tree/master/storage/mysql"
+        "url": "https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/storage/mysql"
     },
     "license": "Apache-2.0",
     "keywords": [

--- a/storage/redis/package.json
+++ b/storage/redis/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/storage/redis"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/storage/redis"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "redis" ],

--- a/storage/sqlite/package.json
+++ b/storage/sqlite/package.json
@@ -7,7 +7,8 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/node-red/node-red-nodes/tree/master/storage/sqlite"
+        "url": "https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/storage/sqlite"
     },
     "engines": {
         "node": ">=12"

--- a/storage/tail/package.json
+++ b/storage/tail/package.json
@@ -7,7 +7,8 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/node-red/node-red-nodes/storage/tail/"
+        "url": "https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/storage/tail"
     },
     "license": "Apache-2.0",
     "keywords": [

--- a/time/suncalc/package.json
+++ b/time/suncalc/package.json
@@ -7,7 +7,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/time"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/time/suncalc"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "suncalc" ],

--- a/time/timeswitch/package.json
+++ b/time/timeswitch/package.json
@@ -8,7 +8,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/time/scheduler"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/time/timeswitch"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "timeswitch", "timer", "scheduler" ],

--- a/utility/annotate-image/package.json
+++ b/utility/annotate-image/package.json
@@ -7,7 +7,8 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/node-red/node-red-nodes/tree/master/utility/image-annotate"
+        "url": "https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/utility/image-annotate"
     },
     "license": "Apache-2.0",
     "keywords": [

--- a/utility/daemon/package.json
+++ b/utility/daemon/package.json
@@ -6,7 +6,8 @@
     },
     "repository" : {
         "type":"git",
-        "url":"https://github.com/node-red/node-red-nodes/tree/master/utility/daemon"
+        "url":"https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/utility/daemon"
     },
     "license": "Apache-2.0",
     "keywords": [ "node-red", "daemon", "shell", "exec" ],

--- a/utility/exif/package.json
+++ b/utility/exif/package.json
@@ -10,7 +10,8 @@
     ],
     "repository": {
         "type": "git",
-        "url": "https://github.com/node-red/node-red-nodes/tree/master/utility/exif"
+        "url": "https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/utility/exif"
     },
     "license": "Apache-2.0",
     "keywords": [

--- a/utility/group/package.json
+++ b/utility/group/package.json
@@ -5,7 +5,8 @@
     "dependencies": {},
     "repository": {
         "type": "git",
-        "url": "https://github.com/node-red/node-red-nodes/tree/master/utility/group"
+        "url": "https://github.com/node-red/node-red-nodes.git",
+        "directory": "tree/master/utility/group"
     },
     "license": "Apache-2.0",
     "keywords": [


### PR DESCRIPTION
Update the package.json for each node to point to the directory within the repo that hosts the code for the package in question.  as per https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository

This means that these node will now pass the repo-check in node-red-dev

I've not increased the version numbers as I'm not sure its worth publishing an update just for this change but these should find their way through to npm eventually with other updates.