### PR TITLE
Change mysql library to mysql2 as it is more maintained and support latest mysql authention

### DIFF
--- a/social/email/package.json
+++ b/social/email/package.json
@@ -4,9 +4,9 @@
   "description": "Node-RED nodes to send and receive simple emails.",
   "dependencies": {
     "imap": "^0.8.19",
-    "poplib": "^0.1.7",
     "mailparser": "^3.4.0",
-    "nodemailer": "^6.7.0",
+    "nodemailer": "~6.7.1",
+    "poplib": "^0.1.7",
     "smtp-server": "^3.9.0"
   },
   "bundledDependencies": [

--- a/storage/mysql/68-mysql.html
+++ b/storage/mysql/68-mysql.html
@@ -22,7 +22,7 @@
     </div>
     <div class="form-row">
         <label for="node-config-input-tz"><i class="fa fa-clock-o"></i> <span data-i18n="mysql.label.timezone"></span></label>
-        <input type="text" id="node-config-input-tz">
+        <input type="text" id="node-config-input-tz" placeholder="&#177;hh:mm">
     </div>
     <div class="form-row">
         <label for="node-config-input-charset"><i class="fa fa-language"></i> <span data-i18n="mysql.label.charset"></span></label>
@@ -32,6 +32,7 @@
         <label for="node-config-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
         <input type="text" id="node-config-input-name" data-i18n="[placeholder]node-red:common.label.name">
     </div>
+    <div class="form-tips"><span data-i18n="[html]mysql.tip"></span></div>
 </script>
 
 <script type="text/javascript">

--- a/storage/mysql/68-mysql.js
+++ b/storage/mysql/68-mysql.js
@@ -2,7 +2,7 @@
 module.exports = function(RED) {
     "use strict";
     var reconnect = RED.settings.mysqlReconnectTime || 20000;
-    var mysqldb = require('mysql');
+    var mysqldb = require('mysql2');
 
     function MySQLNode(n) {
         RED.nodes.createNode(this,n);

--- a/storage/mysql/68-mysql.js
+++ b/storage/mysql/68-mysql.js
@@ -41,7 +41,7 @@ module.exports = function(RED) {
                     timezone : node.tz,
                     insecureAuth: true,
                     multipleStatements: true,
-                    connectionLimit: 50,
+                    connectionLimit: RED.settings.mysqlConnectionLimit || 50,
                     connectTimeout: 30000,
                     charset: node.charset,
                     decimalNumbers: true

--- a/storage/mysql/68-mysql.js
+++ b/storage/mysql/68-mysql.js
@@ -116,7 +116,7 @@ module.exports = function(RED) {
                         if (Array.isArray(msg.payload)) {
                             bind = msg.payload;
                             node.mydbConfig.pool.on('acquire', function(connection) {
-                                    connection.config.queryFormat = null;
+                                connection.config.queryFormat = null;
                             });
                         }
                         else if (typeof msg.payload === 'object' && msg.payload !== null) {
@@ -142,34 +142,12 @@ module.exports = function(RED) {
                                 node.error(err,msg);
                             }
                             else {
-                                // if (rows.constructor.name === "OkPacket") {
-                                //     msg.payload = JSON.parse(JSON.stringify(rows));
-                                // }
-                                // else if (rows.constructor.name === "Array") {
-                                //     if (rows[0] && rows[0].constructor.name === "RowDataPacket") {
-                                //         msg.payload = rows.map(v => Object.assign({}, v));
-                                //     }
-                                //     else if (rows[0] && rows[0].constructor.name === "Array") {
-                                //         if (rows[0][0] && rows[0][0].constructor.name === "RowDataPacket") {
-                                //             msg.payload = rows.map(function(v) {
-                                //                 if (!Array.isArray(v)) { return v; }
-                                //                 v.map(w => Object.assign({}, w))
-                                //             });
-                                //         }
-                                //         else { msg.payload = rows; }
-                                //     }
-                                //     else  { msg.payload = rows; }
-                                // }
-                                // else { msg.payload = rows; }
                                 msg.payload = rows;
                                 send(msg);
                                 status = {fill:"green",shape:"dot",text:RED._("mysql.status.ok")};
                                 node.status(status);
                             }
                             if (done) { done(); }
-                            // if (node.mydbConfig.pool._freeConnections.indexOf(node.mydbConfig.connection) === -1) {
-                            //     node.mydbConfig.connection.release();
-                            // }
                         });
                     }
                     else {

--- a/storage/mysql/68-mysql.js
+++ b/storage/mysql/68-mysql.js
@@ -44,7 +44,8 @@ module.exports = function(RED) {
                     connectionLimit: 50,
                     timeout: 30000,
                     connectTimeout: 30000,
-                    charset: node.charset
+                    charset: node.charset,
+                    decimalNumbers: true
                 });
             }
 

--- a/storage/mysql/68-mysql.js
+++ b/storage/mysql/68-mysql.js
@@ -42,7 +42,6 @@ module.exports = function(RED) {
                     insecureAuth: true,
                     multipleStatements: true,
                     connectionLimit: 50,
-                    timeout: 30000,
                     connectTimeout: 30000,
                     charset: node.charset,
                     decimalNumbers: true

--- a/storage/mysql/68-mysql.js
+++ b/storage/mysql/68-mysql.js
@@ -112,43 +112,41 @@ module.exports = function(RED) {
                 if (node.mydbConfig.connected) {
                     if (typeof msg.topic === 'string') {
                         //console.log("query:",msg.topic);
-                        var bind = [];
-                        if (Array.isArray(msg.payload)) {
-                            bind = msg.payload;
-                            node.mydbConfig.pool.on('acquire', function(connection) {
-                                connection.config.queryFormat = null;
-                            });
-                        }
-                        else if (typeof msg.payload === 'object' && msg.payload !== null) {
-                            bind = msg.payload;
-                            node.mydbConfig.pool.on('acquire', function(connection) {
-                                connection.config.queryFormat = function(query, values) {
-                                    if (!values) {
-                                        return query;
-                                    }
-                                    return query.replace(/\:(\w+)/g, function(txt, key) {
-                                        if (values.hasOwnProperty(key)) {
-                                            return this.escape(values[key]);
-                                        }
-                                        return txt;
-                                    }.bind(this));
-                                };
-                            });
-                        }
-                        node.mydbConfig.pool.query(msg.topic, bind, function(err, rows) {
+                        node.mydbConfig.pool.getConnection(function (err, conn) {
                             if (err) {
-                                status = {fill:"red",shape:"ring",text:RED._("mysql.status.error")+": "+err.code};
+                                conn.release()
+                                status = { fill: "red", shape: "ring", text: RED._("mysql.status.error") + ": " + err.code };
                                 node.status(status);
-                                node.error(err,msg);
+                                node.error(err, msg);
+                                if (done) { done(); }
+                                return
                             }
-                            else {
-                                msg.payload = rows;
-                                send(msg);
-                                status = {fill:"green",shape:"dot",text:RED._("mysql.status.ok")};
-                                node.status(status);
+
+                            var bind = [];
+                            if (Array.isArray(msg.payload)) {
+                                bind = msg.payload;
                             }
-                            if (done) { done(); }
-                        });
+                            else if (typeof msg.payload === 'object' && msg.payload !== null) {
+                                bind = msg.payload;
+                            }
+                            conn.config.queryFormat = Array.isArray(msg.payload) ? null : customQueryFormat
+                            conn.query(msg.topic, bind, function (err, rows) {
+                                conn.release()
+                                if (err) {
+                                    status = { fill: "red", shape: "ring", text: RED._("mysql.status.error") + ": " + err.code };
+                                    node.status(status);
+                                    node.error(err, msg);
+                                }
+                                else {
+                                    msg.payload = rows;
+                                    send(msg);
+                                    status = { fill: "green", shape: "dot", text: RED._("mysql.status.ok") };
+                                    node.status(status);
+                                }
+                                if (done) { done(); }
+                            });
+                        })
+
                     }
                     else {
                         if (typeof msg.topic !== 'string') { node.error("msg.topic : "+RED._("mysql.errors.notstring")); done(); }
@@ -177,4 +175,16 @@ module.exports = function(RED) {
         }
     }
     RED.nodes.registerType("mysql",MysqlDBNodeIn);
+}
+
+function customQueryFormat(query, values) {
+    if (!values) {
+        return query;
+    }
+    return query.replace(/\:(\w+)/g, function(txt, key) {
+        if (values.hasOwnProperty(key)) {
+            return this.escape(values[key]);
+        }
+        return txt;
+    }.bind(this));
 }

--- a/storage/mysql/locales/en-US/68-mysql.json
+++ b/storage/mysql/locales/en-US/68-mysql.json
@@ -19,6 +19,7 @@
             "notstring": "the query is not defined as a string",
             "notconnected": "Database not connected",
             "notconfigured": "MySQL database not configured"
-        }
+        },
+        "tip": "Tip: The timezone should be specified as &#177;hh:mm or leave blank for 'local'."
     }
 }

--- a/storage/mysql/package.json
+++ b/storage/mysql/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-node-mysql",
-    "version": "1.0.0-beta-3",
+    "version": "1.0.0-beta-5",
     "description": "A Node-RED node to read and write to a MySQL database",
     "dependencies": {
         "mysql2": "^2.3.3"

--- a/storage/mysql/package.json
+++ b/storage/mysql/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-node-mysql",
-    "version": "1.0.0-beta",
+    "version": "1.0.0-beta-2",
     "description": "A Node-RED node to read and write to a MySQL database",
     "dependencies": {
         "mysql2": "^2.3.3"

--- a/storage/mysql/package.json
+++ b/storage/mysql/package.json
@@ -1,9 +1,9 @@
 {
     "name": "node-red-node-mysql",
-    "version": "0.3.0",
+    "version": "1.0.0-beta",
     "description": "A Node-RED node to read and write to a MySQL database",
     "dependencies": {
-        "mysql": "^2.18.1"
+        "mysql2": "^2.3.3"
     },
     "repository": {
         "type": "git",

--- a/storage/mysql/package.json
+++ b/storage/mysql/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-node-mysql",
-    "version": "1.0.0-beta-2",
+    "version": "1.0.0-beta-3",
     "description": "A Node-RED node to read and write to a MySQL database",
     "dependencies": {
         "mysql2": "^2.3.3"


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

The existing mysql library is rarely maintained and does not support the latest default mysql authentication mechanism out of the box (you have to set the server to insecure or old auth types). The mysql2 library does support it and is well maintained. This PR swaps to that library. Functionally it is "almost" identical - but there are a couple of edge case changes.

1)  we have set DECIMAL and NEWDECIMAL types to return number - see https://github.com/sidorares/node-mysql2/tree/master/documentation#known-incompatibilities-with-node-mysql

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
