### PR TITLE
fixed check for python2 module while using python3

### DIFF
--- a/hardware/neopixel/neopix
+++ b/hardware/neopixel/neopix
@@ -4,4 +4,8 @@ python_cmd='python3'
 command -v python3 > /dev/null || python_cmd=`python`
 
 BASEDIR=$(dirname $0)
-sudo $python_cmd -u $BASEDIR/neopix.py $@
+if [ "$1" == "check" ];then
+	$python_cmd -c "import rpi_ws281x"
+else
+	sudo $python_cmd -u $BASEDIR/neopix.py $@
+fi

--- a/hardware/neopixel/neopixel.js
+++ b/hardware/neopixel/neopixel.js
@@ -14,7 +14,7 @@ module.exports = function(RED) {
             RED.log.warn("rpi-neopixels : "+RED._("node-red:rpi-gpio.errors.ignorenode"));
             allOK = false;
         }
-        else if (execSync('python -c "import rpi_ws281x"').toString() !== "") {
+        else if (execSync(piCommand+" check").toString() !== "") {
             RED.log.warn("rpi-neopixels : Can't find neopixel python library");
             allOK = false;
         }


### PR DESCRIPTION
<!--
## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

I found a check for the rpi_ws281x python module by calling 'python -c "import rpi_ws281x"' in hardware/neopixel/neopixel.js. The later used wrapper shell script neopix prefers to call python3 wich is also available. This leads to the situation that one has to install the rpi_ws281x in python2 to get the check passed and in python3 to get neopix.py running. 
To fix the behavior i moved the check to the wrapper script and replaced the check in neopixel.js with a script call.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
