### PR TITLE
Special requirements for DietPi node-red installations

### DIFF
--- a/io/mdns/README.md
+++ b/io/mdns/README.md
@@ -14,6 +14,15 @@ please read the [install instructions](https://www.npmjs.com/package/mdns) for t
 For Debian / Ubuntu this requires installing
 
         sudo apt-get install libavahi-compat-libdnssd-dev libudev-dev
+        
+> For DietPi installations, if you encounter this error when executing the node
+>
+>        Error: getaddrinfo -3008
+>        
+> You may need to install `libnss-mdns` as well
+>
+>        sudo apt-get install libnss-mdns
+
 
 Install
 -------


### PR DESCRIPTION


<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

I wasted several hours investigating the `Error: getaddrinfo -3008` and couldn't solve it with any of the solutions proposed on this repo's issues nor on the dependency (`mdns` repo)[https://github.com/agnat/node_mdns].

In the end, it boiled down to DietP's minimalistic approach to default packages that don't even provide `avahi-daemon` out of the box (as you need to install it with `dietpi-software`) and looks like this wasn't enough for this node to work, I needed an extra prerequisite lib: `libnss-mdns`. 

I didn't try uninstalling `libavahi-compat-libdnssd-dev` or  `libudev-dev` to check if those are not needed for DietPi installations, but what solved in my case was installing this extra package.

I hope it helps someone in the future

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
