### PR TITLE
Include `Content-Length` header when POSTing to sockets

### DIFF
--- a/hardware/wemo/lib/wemo.js
+++ b/hardware/wemo/lib/wemo.js
@@ -338,6 +338,17 @@ WeMoNG.prototype.get = function get(deviceID) {
 }
 
 WeMoNG.prototype.toggleSocket = function toggleSocket(socket, on) {
+
+  var body = [
+      postbodyheader,
+      '<u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">',
+      '<BinaryState>%s</BinaryState>',
+      '</u:SetBinaryState>',
+      postbodyfooter
+    ].join('\n');
+
+  var data = util.format(body, on);
+
   var postoptions = {
     host: socket.ip,
     port: socket.port,
@@ -346,7 +357,8 @@ WeMoNG.prototype.toggleSocket = function toggleSocket(socket, on) {
     headers: {
       'SOAPACTION': '"urn:Belkin:service:basicevent:1#SetBinaryState"',
       'Content-Type': 'text/xml; charset="utf-8"',
-      'Accept': ''
+      'Accept': '',
+      'Content-Length': data.length
     }
   };
 
@@ -372,15 +384,7 @@ WeMoNG.prototype.toggleSocket = function toggleSocket(socket, on) {
       post_request.abort();
     });
 
-    var body = [
-      postbodyheader,
-      '<u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">',
-      '<BinaryState>%s</BinaryState>',
-      '</u:SetBinaryState>',
-      postbodyfooter
-    ].join('\n');
-
-    post_request.write(util.format(body, on));
+    post_request.write(data);
     post_request.end();
 }
 
@@ -394,6 +398,7 @@ WeMoNG.prototype.getSocketStatus = function getSocketStatus(socket) {
       'SOAPACTION': getSocketState.action,
       'Content-Type': 'text/xml; charset="utf-8"',
       'Accept': ''
+      'Content-Length': getSocketState.body.length 
     }
   }
 


### PR DESCRIPTION
Newer sockets close the connection when starting to write data without this header.

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
