### PR TITLE
Better inplace upgrade SNMP nodes

### DIFF
--- a/io/snmp/package.json
+++ b/io/snmp/package.json
@@ -1,6 +1,6 @@
 {
     "name"          : "node-red-node-snmp",
-    "version"       : "1.0.0",
+    "version"       : "1.0.1",
     "description"   : "A Node-RED node that gets and sets SNMP oid values. Supports v1, v2c and v3",
     "dependencies"  : {
         "net-snmp"  : "^3.6.3"

--- a/io/snmp/snmp.html
+++ b/io/snmp/snmp.html
@@ -12,14 +12,20 @@
 <script type="text/javascript" id="node-red-node-snmp-common-script">
     const node_snmp_common = {
         oneditprepare: function (node) {
+            const compat = { "v1": "1", "v2": "2c", "v2c": "2c", "v3": "3" };
+            if(compat[node.version]) {
+                node.version = compat[node.version];
+            } else if(["1","2c","3"].indexOf(node.version) < 0) {
+                node.version = "1";
+            }
             $("#node-input-version").on("change", function(evt) {
-                const isV3 = $("#node-input-version").val() === "v3";
+                const isV3 = $("#node-input-version").val() === "3";
                 $(".form-row-snmpv1v2").toggleClass("hidden", isV3);
                 $(".form-row-snmpv3").toggleClass("hidden", !isV3);
                 $("#node-input-auth").trigger("change");
             });
             $("#node-input-auth").on("change", function(evt) {
-                const isV3 = $("#node-input-version").val() === "v3";
+                const isV3 = $("#node-input-version").val() === "3";
                 const auth = $("#node-input-auth").val();
                 if(isV3) {
                     switch (auth) {
@@ -38,6 +44,10 @@
                     }  
                 }
             });
+            $("#node-input-version").val(node.version);
+            if(!$("#node-input-auth").val()) {
+                $("#node-input-auth").val("noAuthNoPriv");
+            }
             $("#node-input-version").trigger("change");
         }
     }
@@ -50,9 +60,9 @@
     <div class="form-row">
         <label for="node-input-version"><i class="fa fa-bookmark"></i> Version</label>
         <select type="text" id="node-input-version" style="width:150px;">
-            <option value="v1">v1</option>
-            <option value="v2c">v2c</option>
-           <option value="v3">v3</option>
+            <option value="1">v1</option>
+            <option value="2c">v2c</option>
+           <option value="3">v3</option>
         </select>
         <span style="margin-left:50px;">Timeout</span>
         <input type="text" id="node-input-timeout" placeholder="secs" style="width:50px; direction:rtl; vertical-align:baseline;">&nbsp;S
@@ -126,7 +136,7 @@
         color: "YellowGreen",
         defaults: {
             host: { value: "127.0.0.1" },
-            version: { value: "v1", required: true },
+            version: { value: "1", required: true },
             timeout: { value: 5 },
             community: { value: "public" },
             auth: { value: "noAuthNoPriv", required: true },
@@ -163,10 +173,10 @@
     <div class="form-row">
         <label for="node-input-version"><i class="fa fa-bookmark"></i> Version</label>
         <select type="text" id="node-input-version" style="width:150px;">
-            <option value="v1">v1</option>
-            <option value="v2c">v2c</option>
+            <option value="1">v1</option>
+            <option value="2c">v2c</option>
 			<!-- Following Data is used for V3 Only -->
-            <option value="v3">v3</option>
+            <option value="3">v3</option>
 			<!-- End of unique data for V3 -->	
         </select>
         <span style="margin-left:50px;">Timeout</span>
@@ -251,7 +261,7 @@
         color: "YellowGreen",
         defaults: {
             host: { value: "127.0.0.1" },
-            version: { value: "v1", required: true },
+            version: { value: "1", required: true },
             timeout: { value: 5 },
             community: { value: "public" },
             auth: { value: "noAuthNoPriv", required: true },
@@ -295,10 +305,10 @@
     <div class="form-row">
         <label for="node-input-version"><i class="fa fa-bookmark"></i> Version</label>
         <select type="text" id="node-input-version" style="width:150px;">
-            <option value="v1">v1</option>
-            <option value="v2c">v2c</option>
+            <option value="1">v1</option>
+            <option value="2c">v2c</option>
 			<!-- Following Data is used for V3 Only -->
-            <option value="v3">v3</option>
+            <option value="3">v3</option>
 			<!-- End of unique data for V3 -->	
         </select>
         <span style="margin-left:50px;">Timeout</span>
@@ -373,7 +383,7 @@
         color: "YellowGreen",
         defaults: {
             host: { value: "127.0.0.1" },
-            version: { value: "v1", required: true },
+            version: { value: "1", required: true },
             timeout: { value: 5 },
             community: { value: "public" },
             auth: { value: "noAuthNoPriv", required: true },
@@ -410,10 +420,10 @@
     <div class="form-row">
         <label for="node-input-version"><i class="fa fa-bookmark"></i> Version</label>
         <select type="text" id="node-input-version" style="width:150px;">
-            <option value="v1">v1</option>
-            <option value="v2c">v2c</option>
+            <option value="1">v1</option>
+            <option value="2c">v2c</option>
 			<!-- Following Data is used for V3 Only -->
-            <option value="v3">v3</option>
+            <option value="3">v3</option>
 			<!-- End of unique data for V3 -->	
         </select>
         <span style="margin-left:50px;">Timeout</span>
@@ -488,7 +498,7 @@
         color: "YellowGreen",
         defaults: {
             host: { value: "127.0.0.1" },
-            version: { value: "v1", required: true },
+            version: { value: "1", required: true },
             timeout: { value: 5 },
             community: { value: "public" },
             auth: { value: "noAuthNoPriv", required: true },
@@ -526,10 +536,10 @@
     <div class="form-row">
         <label for="node-input-version"><i class="fa fa-bookmark"></i> Version</label>
         <select type="text" id="node-input-version" style="width:150px;">
-            <option value="v1">v1</option>
-            <option value="v2c">v2c</option>
+            <option value="1">v1</option>
+            <option value="2c">v2c</option>
 			<!-- Following Data is used for V3 Only -->
-            <option value="v3">v3</option>
+            <option value="3">v3</option>
 			<!-- End of unique data for V3 -->	
         </select>
         <span style="margin-left:50px;">Timeout</span>
@@ -607,7 +617,7 @@
         color: "YellowGreen",
         defaults: {
             host: { value: "127.0.0.1" },
-            version: { value: "v1", required: true },
+            version: { value: "1", required: true },
             timeout: { value: 5 },
             community: { value: "public" },
             auth: { value: "noAuthNoPriv", required: true },

--- a/io/snmp/snmp.js
+++ b/io/snmp/snmp.js
@@ -61,15 +61,20 @@ module.exports = function (RED) {
         const sessionid = generateUUID();
         const user = {}
         const options = {};
-
+        const compat = { "v1": "1", "v2": "2c", "v2c": "2c", "v3": "3" };
+        if(compat[node.version]) {
+            node.version = compat[node.version];
+        } else if(["1","2c","3"].indexOf(node.version) < 0) {
+            node.version = "1";
+        }
         options.version = node.version;
-        if (node.version === "v1") {
+        if (node.version === "1") {
             options.version = SNMP.Version1;
             user.community = node.community || msg.community;
-        } else if (node.version === "v2c") {
+        } else if (node.version === "2c") {
             options.version = SNMP.Version2c;
             user.community = node.community || msg.community;
-        } else if (node.version === "v3") {
+        } else if (node.version === "3") {
             user.name = node.username || msg.username || "";
             user.level = SNMP.SecurityLevel.noAuthNoPriv;
             user.authProtocol = SNMP.AuthProtocols.none;


### PR DESCRIPTION
fixes #907

## Types of changes


- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

### SNMP nodes...
Improve the upgrade path from v1.0.0 and below to this version (v1.0.1)
* Ensures `version` has a value (prevents ` TypeError: argument must be a Number`)
* Return the version dropdown options values back to what they were pre v1.0.0 (better inplace compatibility)
* Ensure any upgrades to v1.0.0 are inplace upgraded to v1.0.1


## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
