### PR TITLE
Email node gmail stopped less secure apps support

### DIFF
--- a/social/email/locales/en-US/61-email.html
+++ b/social/email/locales/en-US/61-email.html
@@ -7,8 +7,7 @@
     <p>You may optionally set <code>msg.from</code> in the payload which will override the <code>userid</code>
     default value.</p>
     <h3>Gmail users</h3>
-    <p>If you are accessing Gmail you may need to either enable <a target="_new" href="https://support.google.com/mail/answer/185833?hl=en">an application password</a>,
-    or enable <a target="_new" href="https://support.google.com/accounts/answer/6010255?hl=en">less secure access</a> via your Google account settings.</p>
+    <p>If you are accessing Gmail you should use <a target="_new" href="https://support.google.com/mail/answer/185833?hl=en">an application password</a>.</p>
     <h3>Details</h3>
     <p>The payload can be html format. You may supply a separate plaintext version using <code>msg.plaintext</code>.
     If you don't and <code>msg.payload</code> contains html, it will also be used for the plaintext.


### PR DESCRIPTION
Google (gmail) stops support of "less secure apps" and so should be removed from doc. 
Quote from https://support.google.com/accounts/answer/6010255
```
To help keep your account secure, from May 30, 2022, ​​Google no longer supports the use of third
-party apps or devices which ask you to sign in to your Google Account using only your username and password.
```

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
