### PR TITLE
Add IOT2050 board into mraa Intel nodes

### DIFF
--- a/hardware/intel/mraa-gpio-ain.html
+++ b/hardware/intel/mraa-gpio-ain.html
@@ -1,7 +1,7 @@
 
 <script type="text/javascript">
     RED.nodes.registerType('mraa-gpio-ain',{
-        category: 'Intel gpio',
+        category: 'GPIO',
         color: '#a6bbcf',
         paletteLabel: 'analogue',
         defaults: {
@@ -27,6 +27,7 @@
                 if (data === 5) { t = "Raspberry Pi"; }
                 if (data === 6) { t = "Beaglebone"; }
                 if (data === 7) { t = "Banana"; }
+                if (data === 25) { t = "IOT2050"; }
                 $('#btype').text(t);
                 $('#node-input-pin').val(pinnow);
             });
@@ -62,7 +63,7 @@
 </script>
 
 <script type="text/x-red" data-help-name="mraa-gpio-ain">
-    <p>An analogue input pin for an Intel Galileo or Edison board that is read every <i>interval</i> milliseconds.</p>
+    <p>An analogue input pin for a board that is read every <i>interval</i> milliseconds.</p>
     <p>The <code>msg.payload</code> will contain the value, and <code>msg.topic</code>
     contains "{the_board_name}/A{the pin number}".</p>
     <p>The value is only sent if it is different from the previously read value.</p>

--- a/hardware/intel/mraa-gpio-ain.js
+++ b/hardware/intel/mraa-gpio-ain.js
@@ -25,6 +25,7 @@ module.exports = function(RED) {
 
         this.on('close', function() {
             clearInterval(this.timer);
+            node.x.close();
         });
     }
     RED.nodes.registerType("mraa-gpio-ain", gpioAin);

--- a/hardware/intel/mraa-gpio-ain.js
+++ b/hardware/intel/mraa-gpio-ain.js
@@ -11,6 +11,10 @@ module.exports = function(RED) {
         var node = this;
         var msg = { topic:node.board+"/A"+node.pin };
         var old = -99999;
+        // ADC set to 12 for IOT2050
+        if (this.board === "SIMATIC IOT2050") {
+            node.x.setBit(12);
+        }
         this.timer = setInterval(function() {
             msg.payload = node.x.read();
             if (msg.payload !== old) {

--- a/hardware/intel/mraa-gpio-din.html
+++ b/hardware/intel/mraa-gpio-din.html
@@ -68,6 +68,7 @@
             <option value="17">D17</option>
             <option value="18">D18</option>
             <option value="19">D19</option>
+            <option value="20">USER button</option>
         </select>
     </div>
     <div class="form-row">

--- a/hardware/intel/mraa-gpio-dout.html
+++ b/hardware/intel/mraa-gpio-dout.html
@@ -1,7 +1,7 @@
 
 <script type="text/javascript">
     RED.nodes.registerType('mraa-gpio-dout',{
-        category: 'Intel gpio',
+        category: 'GPIO',
         color: '#a6bbcf',
         paletteLabel: 'digital',
         defaults: {
@@ -36,6 +36,7 @@
                 if (data === 5) { t = "Raspberry Pi"; }
                 if (data === 6) { t = "Beaglebone"; }
                 if (data === 7) { t = "Banana"; }
+                if (data === 25) { t = "IOT2050"; }
                 $('#btype').text(t);
                 if (data === 0) {
                     $('#node-input-pin').append($("<option></option>").attr("value",14).text("LED - Galileo v1"));
@@ -100,6 +101,6 @@
 </script>
 
 <script type="text/x-red" data-help-name="mraa-gpio-dout">
-    <p>A digital output pin for an Intel Galileo or Edison board.</p>
+    <p>A digital output pin for a board.</p>
     <p>The <code>msg.payload</code> should contain the value 0 or 1.</p>
 </script>

--- a/hardware/intel/mraa-gpio-dout.js
+++ b/hardware/intel/mraa-gpio-dout.js
@@ -29,6 +29,7 @@ module.exports = function(RED) {
         });
 
         this.on('close', function() {
+            node.p.close();
         });
     }
     RED.nodes.registerType("mraa-gpio-dout", gpioDout);

--- a/hardware/intel/mraa-gpio-led.html
+++ b/hardware/intel/mraa-gpio-led.html
@@ -1,0 +1,77 @@
+
+<script type="text/javascript">
+    RED.nodes.registerType('mraa-gpio-led',{
+        category: 'GPIO',
+        color: '#a6bbcf',
+        paletteLabel: 'led',
+        defaults: {
+            name: {value:""},
+            pin:  {value:"", required: true},
+        },
+        inputs:1,
+        outputs:0,
+        icon: "arrow.png",
+        align: "right",
+        label: function() {
+            return this.name || "led";
+        },
+        labelStyle: function() {
+            return this.name?"node_label_italic":"";
+        },
+        oneditprepare: function() {
+            var pinnow = this.pin;
+            $.getJSON('mraa-gpio/'+this.id,function(data) {
+                var t = "unknown";
+                if (data === 0) { t = "Galileo v1"; }
+                if (data === 1) { t = "Galileo v2"; }
+                if (data === 2) { t = "Edison Fab C"; }
+                if (data === 3) { t = "DE3813 Baytrail"; }
+                if (data === 4) { t = "Minnow Max"; }
+                if (data === 5) { t = "Raspberry Pi"; }
+                if (data === 6) { t = "Beaglebone"; }
+                if (data === 7) { t = "Banana"; }
+                if (data === 25) { t = "IOT2050"; }
+                $('#btype').text(t);
+                $('#node-input-pin').val(pinnow);
+            });
+            $.getJSON('mraa-version/'+this.id,function(data) {
+                $('#ver-tip').text(data);
+            });
+
+            var setstate = function () {
+                if ($('#node-input-set').is(":checked")) {
+                    $("#node-set-state").show();
+                } else {
+                    $("#node-set-state").hide();
+                }
+            };
+            $("#node-input-set").change(function () { setstate(); });
+            setstate();
+        }
+    });
+</script>
+
+<script type="text/x-red" data-template-name="mraa-gpio-led">
+    <div class="form-row">
+        <label for="node-input-pin"><i class="fa fa-circle"></i> Led</label>
+        <select type="text" id="node-input-pin" style="width: 250px;">
+            <option value='' disabled selected style='display:none;'><span data-i18n="rpi-gpio.label.selectpin"></span></option>
+            <option value="0">User1 Led Green</option>
+            <option value="1">User1 Led Red</option>
+            <option value="2">User1 Led Orange</option>
+            <option value="3">User2 Led Green</option>
+            <option value="4">User2 Led Red</option>
+            <option value="5">User2 Led Orange</option>
+        </select>
+    </div>
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name" style="width: 250px;">
+    </div>
+    <div class="form-tips">Board : <span id="btype">n/a</span><br/>mraa version : <span id="ver-tip">n/a</span></div>
+</script>
+
+<script type="text/x-red" data-help-name="mraa-gpio-led">
+    <p>Led Control for a board.</p>
+    <p>The <code>msg.payload</code> should contain the value 0 or 1.</p>
+</script>

--- a/hardware/intel/mraa-gpio-led.js
+++ b/hardware/intel/mraa-gpio-led.js
@@ -1,0 +1,82 @@
+module.exports = function(RED) {
+    var m = require('mraa');
+    function LEDNode(n) {
+        RED.nodes.createNode(this, n);
+        this.pin = Number(n.pin);
+        this.led0 = new m.Led(0); /*user-led1-green*/
+        this.led1 = new m.Led(1); /*user-led1-red*/
+        this.led2 = new m.Led(2); /*user-led2-green*/
+        this.led3 = new m.Led(3); /*user-led2-red*/
+        this.on("input", function(msg) {
+            if (msg.payload == "1") {
+                switch(this.pin)
+                {
+                    case 0: /*User0 Led Green*/
+                            this.led0.setBrightness(1);
+                        break;
+                    case 1: /*User0 Led Red*/
+                            this.led1.setBrightness(1);
+                        break;
+                    case 2: /*User0 Orange*/
+                            this.led0.setBrightness(1);
+                            this.led1.setBrightness(1);
+                        break;
+                    case 3: /*User1 Led Green*/
+                            this.led2.setBrightness(1);
+                        break;
+                    case 4: /*User1 Led Red*/
+                            this.led3.setBrightness(1);
+                        break;
+                    case 5: /*User1 Orange*/
+                            this.led2.setBrightness(1);
+                            this.led3.setBrightness(1);
+                        break;
+                    default:
+                        break;
+                }
+            }
+            else {
+                switch(this.pin)
+                {
+                    case 0: /*User1 Led Green*/
+                            this.led0.setBrightness(0);
+                        break;
+                    case 1: /*User1 Led Red*/
+                            this.led1.setBrightness(0);
+                        break;
+                    case 2: /*User1 Orange*/
+                            this.led0.setBrightness(0);
+                            this.led1.setBrightness(0);
+                        break;
+                    case 3: /*User2 Led Green*/
+                            this.led2.setBrightness(0);
+                        break;
+                    case 4: /*User2 Led Red*/
+                            this.led3.setBrightness(0);
+                        break;
+                    case 5: /*User2 Orange*/
+                            this.led2.setBrightness(0);
+                            this.led3.setBrightness(0);
+                        break;
+                    default:
+                        break;
+                }
+            }
+        });
+        this.on('close', function() {
+            this.led0.close();
+            this.led1.close();
+            this.led2.close();
+            this.led3.close();
+        });
+    }
+    RED.nodes.registerType("mraa-gpio-led", LEDNode);
+
+    RED.httpAdmin.get('/mraa-gpio/:id', RED.auth.needsPermission('mraa-gpio.read'), function(req,res) {
+        res.json(m.getPlatformType());
+    });
+
+    RED.httpAdmin.get('/mraa-version/:id', RED.auth.needsPermission('mraa-version.read'), function(req,res) {
+        res.json(m.getVersion());
+    });
+}

--- a/hardware/intel/mraa-gpio-pwm.html
+++ b/hardware/intel/mraa-gpio-pwm.html
@@ -1,7 +1,7 @@
 
 <script type="text/javascript">
     RED.nodes.registerType('mraa-gpio-pwm',{
-        category: 'Intel gpio',
+        category: 'GPIO',
         color: '#a6bbcf',
         paletteLabel: 'pwm',
         defaults: {
@@ -35,6 +35,7 @@
                 if (data === 5) { t = "Raspberry Pi"; }
                 if (data === 6) { t = "Beaglebone"; }
                 if (data === 7) { t = "Banana"; }
+                if (data === 25) { t = "IOT2050"; }
                 $('#type-tip').text(t);
                 $('#node-input-pin').val(pinnow);
             });
@@ -60,13 +61,23 @@
         <label for="node-input-pin"><i class="fa fa-circle"></i> Pin</label>
         <select type="text" id="node-input-pin" style="width: 250px;">
             <option value='' disabled selected style='display:none;'><span data-i18n="rpi-gpio.label.selectpin"></span></option>
-            <option value="3">D3</option>
-            <option value="5">D5</option>
-            <option value="6">D6</option>
-            <option value="9">D9</option>
-            <option value="10">D10</option>
-            <option value="11">D11</option>
-        </select>
+	    <optgroup label="Intel Galileo/Edison">
+                <option value="3">D3</option>
+                <option value="5">D5</option>
+                <option value="6">D6</option>
+                <option value="9">D9</option>
+                <option value="10">D10</option>
+                <option value="11">D11</option>
+            </optgroup>
+            <optgroup label="Siemens IOT2050">
+                <option value="4">D4</option>
+                <option value="5">D5</option>
+                <option value="6">D6</option>
+                <option value="7">D7</option>
+                <option value="8">D8</option>
+                <option value="9">D9</option>
+            </optgroup>
+       </select>
     </div>
     <div class="form-row">
         <label for="node-input-period"><i class="fa fa-clock-o"></i> Period</label>
@@ -80,9 +91,10 @@
 </script>
 
 <script type="text/x-red" data-help-name="mraa-gpio-pwm">
-    <p>A pulse width modulation (PWM) output pin for an Intel Galileo or Edison board.</p>
+    <p>A pulse width modulation (PWM) output pin for a board.</p>
     <p>The <code>msg.payload</code> should contain a floating point number value
     between 0 and 1, (or a string representation thereof.)</p>
     <p>For servo control set the period to 20mS and vary the input between 0.05 and 0.10</p>
-    <p><b>Note</b> : Only pins 3, 5, 6, 9, 10 & 11 support PWM output.</p>
+    <p><b>Note</b> : Only pins 4, 5, 6, 7, 8 & 9 support PWM output for Siemens IOT2050.</p>
+    <p>Only pins 3, 5, 6, 9, 10 & 11 support PWM output for Intel Galileo/Edison.</p>
 </script>

--- a/hardware/intel/mraa-gpio-pwm.js
+++ b/hardware/intel/mraa-gpio-pwm.js
@@ -21,6 +21,7 @@ module.exports = function(RED) {
 
         this.on('close', function() {
             node.p.enable(false);
+            node.p.close();
         });
     }
     RED.nodes.registerType("mraa-gpio-pwm", gpioPWM);

--- a/hardware/intel/package.json
+++ b/hardware/intel/package.json
@@ -16,7 +16,8 @@
             "mraa-gpio-ain": "mraa-gpio-ain.js",
             "mraa-gpio-din": "mraa-gpio-din.js",
             "mraa-gpio-dout": "mraa-gpio-dout.js",
-            "mraa-gpio-pwm": "mraa-gpio-pwm.js"
+	    "mraa-gpio-pwm": "mraa-gpio-pwm.js",
+            "mraa-gpio-led": "mraa-gpio-led.js"
         }
     },
     "author": {


### PR DESCRIPTION
Porting from IOT2050 to mraa Intel nodes:

1. add IOT2050 board into PWM, AIN, DOUT
2. clean up on close for PWM, AIN, DOUT
3. add LED into GPIO category