### PR TITLE
node-red-node-stomp | Bugfix: show connected state after reconnect

### DIFF
--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -57,6 +57,10 @@ module.exports = function(RED) {
             node.warn("reconnecting");
         });
 
+        node.client.on("reconnect", function() {
+            node.status({fill:"green",shape:"dot",text:"connected"});
+        });
+
         node.client.on("error", function(error) {
             node.status({fill:"grey",shape:"dot",text:"error"});
             node.warn(error);


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Add support for the "reconnect" event from the [node-stomp-client](https://github.com/easternbloc/node-stomp-client) library.

Fix for: https://github.com/node-red/node-red-nodes/issues/985

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
