### PR TITLE
STOMP refactor in accordance with MQTT (shared connection using config node) + client ACK

### DIFF
--- a/io/stomp/18-stomp.html
+++ b/io/stomp/18-stomp.html
@@ -123,6 +123,14 @@
         </select>
     </div>
     <div class="form-row">
+        <label for="node-config-input-ack"><i class="fa fa-check"></i> Enable client acknowledgement</label>
+        <input type="checkbox" id="node-config-input-ack" />
+    </div>
+    <div class="form-tips">
+        Enabling the ACK (acknowledgement) will set the <code>ack</code> header to <code>client</code> while subscribing to topics. 
+        This means the items on the broker queue will not be dequeue'd unless an ACK message is sent using the <code>ack</code> node.
+    </div>
+    <div class="form-row">
         <label for="node-config-input-vhost"><i class="fa fa-server"></i> vhost</label>
         <input type="text" id="node-config-input-vhost" placeholder="Default is null" />
     </div>
@@ -147,6 +155,7 @@
             server: {required:true},
             port: {value:61613,required:true,validate:RED.validators.number()},
             protocolversion: {value:"1.0",required:true},
+            ack: {value: false},
             vhost: {},
             reconnectretries: {value:"0",required:true,validate:RED.validators.number()},
             reconnectdelay: {value:"0.5",required:true,validate:RED.validators.number()},
@@ -158,6 +167,55 @@
         },
         label: function() {
             return (this.name?this.name:this.server+":"+this.port);
+        }
+    });
+</script>
+
+<script type="text/html" data-template-name="stomp ack">
+    <div class="form-row">
+        <label for="node-input-server" style="width: 110px;"><i class="fa fa-bookmark"></i> Server</label>
+        <input type="text" id="node-input-server">
+    </div>
+    <div class="form-row">
+        <label for="node-input-name" style="width: 110px;"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+</script>
+
+<script type="text/html" data-help-name="stomp ack">
+    <p>
+        ACK is used to acknowledge consumption of a message from a subscription using client acknowledgment. When a client has issued a SUBSCRIBE frame with the ack header set to client any messages received from that destination will not be considered to have been consumed (by the server) until the message has been acknowledged via an ACK.
+    </p>
+    <p>
+        The node allows for following inputs:
+        <ul>
+            <li><code>msg.messageId</code>: The id of the message to acknowledge</li>
+            <li><code>msg.subscription</code>: The id of the subscription made using the stomp in node</li>
+            <li><code>msg.transaction</code>: Optional transaction name</li>
+        </ul>
+    </p>
+    <p>
+        See the <a href="https://stomp.github.io/stomp-specification-1.0.html#frame-ACK" target="new">Stomp 1.0 spec</a> for more details.
+    </p>
+</script>
+
+<script type="text/javascript">
+    RED.nodes.registerType('stomp ack',{
+        category: 'output',
+        color:"#e8cfe8",
+        defaults: {
+            name: {value:""},
+            server: {type:"stomp-server",required:true}
+        },
+        inputs:1,
+        outputs:0,
+        icon: "bridge.png",
+        align: "right",
+        label: function() {
+            return this.name||"stomp";
+        },
+        labelStyle: function() {
+            return (this.name)?"node_label_italic":"";
         }
     });
 </script>

--- a/io/stomp/18-stomp.html
+++ b/io/stomp/18-stomp.html
@@ -9,12 +9,16 @@
         <input type="text" id="node-input-topic" placeholder="topic or queue">
     </div>
     <div class="form-row">
-        <label for="node-input-enable_subscriptionid" style="width: 110px;"><i class="fa fa-envelope"></i> Enable subscription ID</label>
-        <input type="checkbox" id="node-input-enable_subscriptionid">
+        <label for="node-config-input-ack"><i class="fa fa-check"></i> Enable client acknowledgement</label>
+        <select type="text" id="node-config-input-ack" style="display: inline-block; width: 250px; vertical-align: top;">
+            <option value="auto">Auto</option>
+            <option value="client">Client</option>
+            <option value="client-individual">Client individual (only v1.1)</option>
+        </select>
     </div>
-    <div class="form-row">
-        <label for="node-input-subscriptionid" style="width: 110px;"><i class="fa fa-envelope"></i> Subscription ID</label>
-        <input type="number" id="node-input-subscriptionid" placeholder="Default: 0">
+    <div class="form-tips">
+        Enabling the ACK (acknowledgement) will set the <code>ack</code> header to <code>client</code> while subscribing to topics. 
+        This means the items on the broker queue will not be dequeue'd unless an ACK message is sent using the <code>ack</code> node.
     </div>
     <div class="form-row">
         <label for="node-input-name" style="width: 110px;"><i class="fa fa-tag"></i> Name</label>
@@ -41,8 +45,7 @@
         defaults: {
             name: {value:""},
             server: {type:"stomp-server",required:true},
-            enable_subscriptionid: {value: false},
-            subscriptionid: {value: 0},
+            ack: {value: "auto"},
             topic: {value:"",required:true}
         },
         inputs:0,
@@ -133,14 +136,6 @@
         </select>
     </div>
     <div class="form-row">
-        <label for="node-config-input-clientAcknowledgement"><i class="fa fa-check"></i> Enable client acknowledgement</label>
-        <input type="checkbox" id="node-config-input-clientAcknowledgement" />
-    </div>
-    <div class="form-tips">
-        Enabling the ACK (acknowledgement) will set the <code>ack</code> header to <code>client</code> while subscribing to topics. 
-        This means the items on the broker queue will not be dequeue'd unless an ACK message is sent using the <code>ack</code> node.
-    </div>
-    <div class="form-row">
         <label for="node-config-input-vhost"><i class="fa fa-server"></i> vhost</label>
         <input type="text" id="node-config-input-vhost" placeholder="Default is null" />
     </div>
@@ -165,7 +160,6 @@
             address: {required:true},
             port: {value:61613,required:true,validate:RED.validators.number()},
             protocolVersion: {value:"1.0",required:true},
-            clientAcknowledgement: {value: false},
             vhost: {},
             reconnectRetries: {value:0,required:true,validate:RED.validators.number()},
             reconnectDelay: {value:1,required:true,validate:RED.validators.number()},
@@ -187,6 +181,10 @@
         <input type="text" id="node-input-server">
     </div>
     <div class="form-row">
+        <label for="node-input-topic" style="width: 110px;"><i class="fa fa-envelope"></i> Destination</label>
+        <input type="text" id="node-input-topic" placeholder="topic or queue">
+    </div>
+    <div class="form-row">
         <label for="node-input-name" style="width: 110px;"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
@@ -200,7 +198,6 @@
         The node allows for following inputs:
         <ul>
             <li><code>msg.messageId</code>: The id of the message to acknowledge</li>
-            <li><code>msg.subscription</code>: The id of the subscription made using the stomp in node</li>
             <li><code>msg.transaction</code>: Optional transaction name</li>
         </ul>
     </p>
@@ -215,7 +212,8 @@
         color:"#e8cfe8",
         defaults: {
             name: {value:""},
-            server: {type:"stomp-server",required:true}
+            server: {type:"stomp-server",required:true},
+            topic: {value:""}
         },
         inputs:1,
         outputs:0,

--- a/io/stomp/18-stomp.html
+++ b/io/stomp/18-stomp.html
@@ -9,7 +9,7 @@
         <input type="text" id="node-input-topic" placeholder="topic or queue">
     </div>
     <div class="form-row">
-        <label for="node-input-ack" style="width: 110px;"><i class="fa fa-check"></i> Message acknowledgement</label>
+        <label for="node-input-ack" style="width: 110px;"><i class="fa fa-check"></i> Message acknowledgment</label>
         <select type="text" id="node-input-ack" style="display: inline-block; width: 250px; vertical-align: top;">
             <option value="auto">Auto</option>
             <option value="client">Client</option>
@@ -17,7 +17,7 @@
         </select>
     </div>
     <div class="form-tips">
-        Enabling the ACK (acknowledgement) will set the <code>ack</code> header to <code>client</code> while subscribing to topics. 
+        Enabling the ACK (acknowledgment) will set the <code>ack</code> header to <code>client</code> while subscribing to topics. 
         This means the items on the broker queue will not be dequeue'd unless an ACK message is sent using the <code>ack</code> node.
     </div>
     <div class="form-row">

--- a/io/stomp/18-stomp.html
+++ b/io/stomp/18-stomp.html
@@ -9,7 +9,7 @@
         <input type="text" id="node-input-topic" placeholder="topic or queue">
     </div>
     <div class="form-row">
-        <label for="node-config-input-ack"><i class="fa fa-check"></i> Enable client acknowledgement</label>
+        <label for="node-config-input-ack" style="width: 110px;"><i class="fa fa-check"></i> Message acknowledgement</label>
         <select type="text" id="node-config-input-ack" style="display: inline-block; width: 250px; vertical-align: top;">
             <option value="auto">Auto</option>
             <option value="client">Client</option>

--- a/io/stomp/18-stomp.html
+++ b/io/stomp/18-stomp.html
@@ -9,11 +9,11 @@
         <input type="text" id="node-input-topic" placeholder="topic or queue">
     </div>
     <div class="form-row">
-        <label for="node-input-enable_subscriptionid" style="width: 110px;"><i class="fa fa-envelope"></i> Destination</label>
+        <label for="node-input-enable_subscriptionid" style="width: 110px;"><i class="fa fa-envelope"></i> Enable subscription ID</label>
         <input type="checkbox" id="node-input-enable_subscriptionid">
     </div>
     <div class="form-row">
-        <label for="node-input-subscriptionid" style="width: 110px;"><i class="fa fa-envelope"></i> Destination</label>
+        <label for="node-input-subscriptionid" style="width: 110px;"><i class="fa fa-envelope"></i> Subscription ID</label>
         <input type="number" id="node-input-subscriptionid">
     </div>
     <div class="form-row">

--- a/io/stomp/18-stomp.html
+++ b/io/stomp/18-stomp.html
@@ -9,8 +9,8 @@
         <input type="text" id="node-input-topic" placeholder="topic or queue">
     </div>
     <div class="form-row">
-        <label for="node-config-input-ack" style="width: 110px;"><i class="fa fa-check"></i> Message acknowledgement</label>
-        <select type="text" id="node-config-input-ack" style="display: inline-block; width: 250px; vertical-align: top;">
+        <label for="node-input-ack" style="width: 110px;"><i class="fa fa-check"></i> Message acknowledgement</label>
+        <select type="text" id="node-input-ack" style="display: inline-block; width: 250px; vertical-align: top;">
             <option value="auto">Auto</option>
             <option value="client">Client</option>
             <option value="client-individual">Client individual (only v1.1)</option>
@@ -45,7 +45,7 @@
         defaults: {
             name: {value:""},
             server: {type:"stomp-server",required:true},
-            ack: {value: "auto"},
+            ack: {value: "auto", required: true},
             topic: {value:"",required:true}
         },
         inputs:0,

--- a/io/stomp/18-stomp.html
+++ b/io/stomp/18-stomp.html
@@ -14,7 +14,7 @@
     </div>
     <div class="form-row">
         <label for="node-input-subscriptionid" style="width: 110px;"><i class="fa fa-envelope"></i> Subscription ID</label>
-        <input type="number" id="node-input-subscriptionid">
+        <input type="number" id="node-input-subscriptionid" placeholder="Default: 0">
     </div>
     <div class="form-row">
         <label for="node-input-name" style="width: 110px;"><i class="fa fa-tag"></i> Name</label>
@@ -42,7 +42,7 @@
             name: {value:""},
             server: {type:"stomp-server",required:true},
             enable_subscriptionid: {value: false},
-            subscriptionid: {value: 0, required:true},
+            subscriptionid: {value: 0},
             topic: {value:"",required:true}
         },
         inputs:0,

--- a/io/stomp/18-stomp.html
+++ b/io/stomp/18-stomp.html
@@ -129,8 +129,8 @@
     </div>
 
     <div class="form-row">
-    <label for="node-config-input-protocolVersion"><i class="fa fa-tag"></i> Protocol Version</label>
-        <select type="text" id="node-config-input-protocolVersion" style="display: inline-block; width: 250px; vertical-align: top;">
+    <label for="node-config-input-protocolversion"><i class="fa fa-tag"></i> Protocol Version</label>
+        <select type="text" id="node-config-input-protocolversion" style="display: inline-block; width: 250px; vertical-align: top;">
             <option value="1.0">v1.0</option>
             <option value="1.1">v1.1</option>
         </select>
@@ -140,12 +140,12 @@
         <input type="text" id="node-config-input-vhost" placeholder="Default is null" />
     </div>
     <div class="form-row">
-        <label for="node-config-input-reconnectRetries"><i class="fa fa-repeat"></i> Reconnect Retries</label>
-        <input type="number" id="node-config-input-reconnectRetries" />
+        <label for="node-config-input-reconnectretries"><i class="fa fa-repeat"></i> Reconnect Retries</label>
+        <input type="number" id="node-config-input-reconnectretries" />
     </div>
     <div class="form-row">
-        <label for="node-config-input-reconnectDelay"><i class="fa fa-clock-o"></i> Reconnect Delay (S)</label>
-        <input type="number" id="node-config-input-reconnectDelay" />
+        <label for="node-config-input-reconnectdelay"><i class="fa fa-clock-o"></i> Reconnect Delay (S)</label>
+        <input type="number" id="node-config-input-reconnectdelay" />
     </div>
     <div class="form-row">
         <label for="node-config-input-name"><i class="fa fa-tag"></i> Name</label>
@@ -159,10 +159,10 @@
         defaults: {
             server: {required:true},
             port: {value:61613,required:true,validate:RED.validators.number()},
-            protocolVersion: {value:"1.0",required:true},
+            protocolversion: {value:"1.0",required:true},
             vhost: {},
-            reconnectRetries: {value:0,required:true,validate:RED.validators.number()},
-            reconnectDelay: {value:1,required:true,validate:RED.validators.number()},
+            reconnectretries: {value:0,required:true,validate:RED.validators.number()},
+            reconnectdelay: {value:1,required:true,validate:RED.validators.number()},
             name: {}
         },
         credentials: {

--- a/io/stomp/18-stomp.html
+++ b/io/stomp/18-stomp.html
@@ -110,9 +110,9 @@
 </script>
 
 <script type="text/html" data-template-name="stomp-server">
-    <div class="form-row node-input-server">
-        <label for="node-config-input-server"><i class="fa fa-bookmark"></i> Server</label>
-        <input class="input-append-left" type="text" id="node-config-input-server" placeholder="localhost" style="width: 45%;" >
+    <div class="form-row node-input-address">
+        <label for="node-config-input-address"><i class="fa fa-bookmark"></i> Address</label>
+        <input class="input-append-left" type="text" id="node-config-input-address" placeholder="localhost" style="width: 45%;" >
         <label for="node-config-input-port" style="margin-left: 10px; width: 35px; "> Port</label>
         <input type="text" id="node-config-input-port" placeholder="Port" style="width:45px">
     </div>
@@ -126,15 +126,15 @@
     </div>
 
     <div class="form-row">
-    <label for="node-config-input-protocolversion"><i class="fa fa-tag"></i> Protocol Version</label>
-        <select type="text" id="node-config-input-protocolversion" style="display: inline-block; width: 250px; vertical-align: top;">
+    <label for="node-config-input-protocolVersion"><i class="fa fa-tag"></i> Protocol Version</label>
+        <select type="text" id="node-config-input-protocolVersion" style="display: inline-block; width: 250px; vertical-align: top;">
             <option value="1.0">v1.0</option>
             <option value="1.1">v1.1</option>
         </select>
     </div>
     <div class="form-row">
-        <label for="node-config-input-ack"><i class="fa fa-check"></i> Enable client acknowledgement</label>
-        <input type="checkbox" id="node-config-input-ack" />
+        <label for="node-config-input-clientAcknowledgement"><i class="fa fa-check"></i> Enable client acknowledgement</label>
+        <input type="checkbox" id="node-config-input-clientAcknowledgement" />
     </div>
     <div class="form-tips">
         Enabling the ACK (acknowledgement) will set the <code>ack</code> header to <code>client</code> while subscribing to topics. 
@@ -145,12 +145,12 @@
         <input type="text" id="node-config-input-vhost" placeholder="Default is null" />
     </div>
     <div class="form-row">
-        <label for="node-config-input-reconnectretries"><i class="fa fa-repeat"></i> Reconnect Retries</label>
-        <input type="number" id="node-config-input-reconnectretries" />
+        <label for="node-config-input-reconnectRetries"><i class="fa fa-repeat"></i> Reconnect Retries</label>
+        <input type="number" id="node-config-input-reconnectRetries" />
     </div>
     <div class="form-row">
-        <label for="node-config-input-reconnectdelay"><i class="fa fa-clock-o"></i> Reconnect Delay (S)</label>
-        <input type="number" id="node-config-input-reconnectdelay" />
+        <label for="node-config-input-reconnectDelay"><i class="fa fa-clock-o"></i> Reconnect Delay (S)</label>
+        <input type="number" id="node-config-input-reconnectDelay" />
     </div>
     <div class="form-row">
         <label for="node-config-input-name"><i class="fa fa-tag"></i> Name</label>
@@ -162,16 +162,14 @@
     RED.nodes.registerType('stomp-server',{
         category: 'config',
         defaults: {
-            server: {required:true},
+            address: {required:true},
             port: {value:61613,required:true,validate:RED.validators.number()},
-            protocolversion: {value:"1.0",required:true},
-            ack: {value: false},
+            protocolVersion: {value:"1.0",required:true},
+            clientAcknowledgement: {value: false},
             vhost: {},
-            reconnectretries: {value:"0",required:true,validate:RED.validators.number()},
-            reconnectdelay: {value:"0.5",required:true,validate:RED.validators.number()},
-            name: {},
-            clientConnection: {value: null},
-            connected: {value: false}
+            reconnectRetries: {value:0,required:true,validate:RED.validators.number()},
+            reconnectDelay: {value:1,required:true,validate:RED.validators.number()},
+            name: {}
         },
         credentials: {
             user: {type:"text"},

--- a/io/stomp/18-stomp.html
+++ b/io/stomp/18-stomp.html
@@ -169,7 +169,9 @@
             vhost: {},
             reconnectretries: {value:"0",required:true,validate:RED.validators.number()},
             reconnectdelay: {value:"0.5",required:true,validate:RED.validators.number()},
-            name: {}
+            name: {},
+            clientConnection: {value: null},
+            connected: {value: false}
         },
         credentials: {
             user: {type:"text"},

--- a/io/stomp/18-stomp.html
+++ b/io/stomp/18-stomp.html
@@ -113,9 +113,9 @@
 </script>
 
 <script type="text/html" data-template-name="stomp-server">
-    <div class="form-row node-input-address">
-        <label for="node-config-input-address"><i class="fa fa-bookmark"></i> Address</label>
-        <input class="input-append-left" type="text" id="node-config-input-address" placeholder="localhost" style="width: 45%;" >
+    <div class="form-row node-input-server">
+        <label for="node-config-input-server"><i class="fa fa-bookmark"></i> Server</label>
+        <input class="input-append-left" type="text" id="node-config-input-server" placeholder="localhost" style="width: 45%;" >
         <label for="node-config-input-port" style="margin-left: 10px; width: 35px; "> Port</label>
         <input type="text" id="node-config-input-port" placeholder="Port" style="width:45px">
     </div>
@@ -157,7 +157,7 @@
     RED.nodes.registerType('stomp-server',{
         category: 'config',
         defaults: {
-            address: {required:true},
+            server: {required:true},
             port: {value:61613,required:true,validate:RED.validators.number()},
             protocolVersion: {value:"1.0",required:true},
             vhost: {},

--- a/io/stomp/18-stomp.html
+++ b/io/stomp/18-stomp.html
@@ -9,6 +9,14 @@
         <input type="text" id="node-input-topic" placeholder="topic or queue">
     </div>
     <div class="form-row">
+        <label for="node-input-enable_subscriptionid" style="width: 110px;"><i class="fa fa-envelope"></i> Destination</label>
+        <input type="checkbox" id="node-input-enable_subscriptionid">
+    </div>
+    <div class="form-row">
+        <label for="node-input-subscriptionid" style="width: 110px;"><i class="fa fa-envelope"></i> Destination</label>
+        <input type="number" id="node-input-subscriptionid">
+    </div>
+    <div class="form-row">
         <label for="node-input-name" style="width: 110px;"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
@@ -33,6 +41,8 @@
         defaults: {
             name: {value:""},
             server: {type:"stomp-server",required:true},
+            enable_subscriptionid: {value: false},
+            subscriptionid: {value: 0, required:true},
             topic: {value:"",required:true}
         },
         inputs:0,

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -195,9 +195,11 @@ module.exports = function(RED) {
                     });
                     
                     node.client.on("reconnect", function(sessionId, numOfRetries) {
+                        node.closing = false;
                         node.connecting = false;
                         node.connected = true;
                         node.sessionId = sessionId;
+                        callback();
 
                         node.log("Reconnected to STOMP server", {sessionId: node.sessionId, url: `${node.options.address}:${node.options.port}`, protocolVersion: node.options.protocolVersion, retries: numOfRetries});
                         setStatusConnected(node, true);

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -364,7 +364,7 @@ module.exports = function(RED) {
 
             if (node.topic) {
                 node.serverConnection.register(node);
-                node.serverConnection.subscribe(node.topic, ack, function(msg) {
+                node.serverConnection.subscribe(node.topic, node.ack, function(msg) {
                     node.send(msg);
                 });
 

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -94,10 +94,10 @@ module.exports = function(RED) {
             // Apply property changes (only if the property exists in the options object)
             setIfHasProperty(options, node, "server", init);
             setIfHasProperty(options, node, "port", init);
-            setIfHasProperty(options, node, "protocolVersion", init);
+            setIfHasProperty(options, node, "protocolversion", init);
             setIfHasProperty(options, node, "vhost", init);
-            setIfHasProperty(options, node, "reconnectRetries", init);
-            setIfHasProperty(options, node, "reconnectDelay", init);
+            setIfHasProperty(options, node, "reconnectretries", init);
+            setIfHasProperty(options, node, "reconnectdelay", init);
 
             if (node.credentials) {
                 node.username = node.credentials.username;
@@ -116,10 +116,10 @@ module.exports = function(RED) {
                 port: node.port * 1,
                 user: node.username,
                 pass: node.password,
-                protocolVersion: node.protocolVersion,
+                protocolVersion: node.protocolversion,
                 reconnectOpts: {
-                    retries: node.reconnectRetries * 1,
-                    delay: node.reconnectDelay * 1000
+                    retries: node.reconnectretries * 1,
+                    delay: node.reconnectdelay * 1000
                 },
                 vhost: node.vhost
             };

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -248,8 +248,8 @@ module.exports = function(RED) {
             if (!node.client) {
                 node.warn("Can't disconnect, connection not initialized.");
                 callback();
-            } else if (node.closing) {
-                // Disconnection already in progress
+            } else if (node.closing || !node.connected) {
+                // Disconnection already in progress or not connected
                 callback();
             } else {
                 waitDisconnect(node.client, 2000).then(() => {

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -452,7 +452,7 @@ module.exports = function(RED) {
             setStatusDisconnected(node);
 
             node.on("input", function(msg, send, done) {
-                node.client.ack(msg.messageId, node.topic, msg.transaction);
+                node.serverConnection.ack(msg.messageId, node.topic, msg.transaction);
                 done();
             });
 

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -59,10 +59,10 @@ module.exports = function(RED) {
         var node = this;
         var msg = {topic:this.topic};
         // Save the client connection to the shared server instance if needed
-        if (!node.server.clientConnection) {
-            node.server.clientConnection = new StompClient(node.stompClientOpts);
+        if (!node.serverConfig.clientConnection) {
+            node.serverConfig.clientConnection = new StompClient(node.stompClientOpts);
         }
-        node.client = node.server.clientConnection;
+        node.client = node.serverConfig.clientConnection;
 
         node.client.on("connect", function() {
             node.status({fill:"green",shape:"dot",text:"connected"});
@@ -134,10 +134,10 @@ module.exports = function(RED) {
 
         var node = this;
         // Save the client connection to the shared server instance if needed
-        if (!node.server.clientConnection) {
-            node.server.clientConnection = new StompClient(node.stompClientOpts);
+        if (!node.serverConfig.clientConnection) {
+            node.serverConfig.clientConnection = new StompClient(node.stompClientOpts);
         }
-        node.client = node.server.clientConnection;
+        node.client = node.serverConfig.clientConnection;
 
         node.client.on("connect", function() {
             node.status({fill:"green",shape:"dot",text:"connected"});
@@ -203,10 +203,10 @@ module.exports = function(RED) {
         // only start connection etc. when acknowledgements are configured to be send by client
         if (node.serverConfig.ack) {
             // Save the client connection to the shared server instance if needed
-            if (!node.server.clientConnection) {
-                node.server.clientConnection = new StompClient(node.stompClientOpts);
+            if (!node.serverConfig.clientConnection) {
+                node.serverConfig.clientConnection = new StompClient(node.stompClientOpts);
             }
-            node.client = node.server.clientConnection;
+            node.client = node.serverConfig.clientConnection;
 
             node.client.on("connect", function() {
                 node.status({fill:"green",shape:"dot",text:"connected"});

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -364,7 +364,7 @@ module.exports = function(RED) {
 
             if (node.topic) {
                 node.serverConnection.register(node);
-                node.serverConnection.subscribe(topic, ack, function(msg) {
+                node.serverConnection.subscribe(node.topic, ack, function(msg) {
                     node.send(msg);
                 });
 
@@ -405,7 +405,7 @@ module.exports = function(RED) {
 
             node.on("input", function(msg, send, done) {
                 if (node.topic && msg.payload) {
-                    node.serverConnection.publish(topic, msg.payload, msg.headers || {});
+                    node.serverConnection.publish(node.topic, msg.payload, msg.headers || {});
                     done();
                 }
             });
@@ -442,7 +442,7 @@ module.exports = function(RED) {
             setStatusDisconnected(node);
 
             node.on("input", function(msg, send, done) {
-                node.client.ack(msg.messageId, n.topic, msg.transaction);
+                node.client.ack(msg.messageId, node.topic, msg.transaction);
                 done();
             });
 

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -334,6 +334,12 @@ module.exports = function(RED) {
             }
         }
 
+        /**
+         * Acknowledge (a) message(s) that was received from the specified queue.
+         * @param {String} queue The queue/topic to send an acknowledgement for
+         * @param {String} messageId ID of the message that was received from the server, which can be found in the reponse header as `message-id`
+         * @param {String} transaction Optional transaction name
+         */
         node.ack = function(queue, messageId, transaction = undefined) {
             if (node.connected) {
                 node.client.ack(messageId, node.subscriptionIds[queue], transaction);
@@ -452,7 +458,7 @@ module.exports = function(RED) {
             setStatusDisconnected(node);
 
             node.on("input", function(msg, send, done) {
-                node.serverConnection.ack(msg.messageId, node.topic, msg.transaction);
+                node.serverConnection.ack(node.topic, msg.messageId, msg.transaction);
                 done();
             });
 

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -87,9 +87,7 @@ module.exports = function(RED) {
         });
 
         // Connect to server if needed and subscribe
-        node.status({fill:"grey",shape:"ring",text:"connecting"});
-
-        function subscribe() {
+        const subscribe = () => {
             node.log('subscribing to: '+node.topic);
             node.client.subscribe(node.topic, node.subscribeHeaders, function(body, headers) {
                 var newmsg={"headers":headers,"topic":node.topic}
@@ -104,6 +102,7 @@ module.exports = function(RED) {
         }
 
         if (!node.server.connected) {
+            node.status({fill:"grey",shape:"ring",text:"connecting"});
             node.client.connect(function(sessionId) {
                 subscribe();
             }, function(error) {
@@ -176,8 +175,8 @@ module.exports = function(RED) {
         });
 
         // Connect to server if needed
-        node.status({fill:"grey",shape:"ring",text:"connecting"});
         if(!node.serverConfig.connected) {
+            node.status({fill:"grey",shape:"ring",text:"connecting"});
             node.client.connect(function(sessionId) {}, function(error) {
                 node.status({fill:"grey",shape:"dot",text:"error"});
                 node.warn(error);
@@ -250,8 +249,8 @@ module.exports = function(RED) {
             });
 
             // Connect to server if needed
-            node.status({fill:"grey",shape:"ring",text:"connecting"});
             if(!node.serverConfig.connected) {
+                node.status({fill:"grey",shape:"ring",text:"connecting"});
                 node.client.connect(function(sessionId) {}, function(error) {
                     node.status({fill:"grey",shape:"dot",text:"error"});
                     node.warn(error);

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -16,6 +16,7 @@ module.exports = function(RED) {
         this.name = n.name;
         this.username = this.credentials.user;
         this.password = this.credentials.password;
+        this.clientConnection = null;
     }
     RED.nodes.registerType("stomp-server",StompServerNode,{
         credentials: {
@@ -57,7 +58,11 @@ module.exports = function(RED) {
 
         var node = this;
         var msg = {topic:this.topic};
-        node.client = new StompClient(node.stompClientOpts);
+        // Save the client connection to the shared server instance if needed
+        if (!node.server.clientConnection) {
+            node.server.clientConnection = new StompClient(node.stompClientOpts);
+        }
+        node.client = node.server.clientConnection;
 
         node.client.on("connect", function() {
             node.status({fill:"green",shape:"dot",text:"connected"});
@@ -128,7 +133,11 @@ module.exports = function(RED) {
         }
 
         var node = this;
-        node.client = new StompClient(node.stompClientOpts);
+        // Save the client connection to the shared server instance if needed
+        if (!node.server.clientConnection) {
+            node.server.clientConnection = new StompClient(node.stompClientOpts);
+        }
+        node.client = node.server.clientConnection;
 
         node.client.on("connect", function() {
             node.status({fill:"green",shape:"dot",text:"connected"});
@@ -193,7 +202,11 @@ module.exports = function(RED) {
 
         // only start connection etc. when acknowledgements are configured to be send by client
         if (node.serverConfig.ack) {
-            node.client = new StompClient(node.stompClientOpts);
+            // Save the client connection to the shared server instance if needed
+            if (!node.server.clientConnection) {
+                node.server.clientConnection = new StompClient(node.stompClientOpts);
+            }
+            node.client = node.server.clientConnection;
 
             node.client.on("connect", function() {
                 node.status({fill:"green",shape:"dot",text:"connected"});

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -90,7 +90,7 @@ module.exports = function(RED) {
             }
 
             // Apply property changes (only if the property exists in the options object)
-            setIfHasProperty(options, node, "address", init);
+            setIfHasProperty(options, node, "server", init);
             setIfHasProperty(options, node, "port", init);
             setIfHasProperty(options, node, "protocolVersion", init);
             setIfHasProperty(options, node, "vhost", init);
@@ -110,7 +110,7 @@ module.exports = function(RED) {
 
             // Build options for passing to the stomp-client API
             node.options = {
-                address: node.address,
+                address: node.server,
                 port: node.port * 1,
                 user: node.username,
                 pass: node.password,
@@ -431,7 +431,7 @@ module.exports = function(RED) {
         } else {
             node.error("Missing server config");
         }
-        
+
         node.on("close", function(removed, done) {
             if (node.serverConnection) {
                 node.serverConnection.deregister(node, true, done);

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -104,8 +104,10 @@ module.exports = function(RED) {
         if (!node.server.connected) {
             node.status({fill:"grey",shape:"ring",text:"connecting"});
             node.client.connect(function(sessionId) {
+                node.serverConfig.connected = true;
                 subscribe();
             }, function(error) {
+                node.serverConfig.connected = false;
                 node.status({fill:"grey",shape:"dot",text:"error"});
                 node.warn(error);
             });
@@ -177,7 +179,10 @@ module.exports = function(RED) {
         // Connect to server if needed
         if(!node.serverConfig.connected) {
             node.status({fill:"grey",shape:"ring",text:"connecting"});
-            node.client.connect(function(sessionId) {}, function(error) {
+            node.client.connect(function(sessionId) {
+                node.serverConfig.connected = true;
+            }, function(error) {
+                node.serverConfig.connected = false;
                 node.status({fill:"grey",shape:"dot",text:"error"});
                 node.warn(error);
             });
@@ -251,7 +256,10 @@ module.exports = function(RED) {
             // Connect to server if needed
             if(!node.serverConfig.connected) {
                 node.status({fill:"grey",shape:"ring",text:"connecting"});
-                node.client.connect(function(sessionId) {}, function(error) {
+                node.client.connect(function(sessionId) {
+                    node.serverConfig.connected = true;
+                }, function(error) {
+                    node.serverConfig.connected = false;
                     node.status({fill:"grey",shape:"dot",text:"error"});
                     node.warn(error);
                 });

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -286,7 +286,7 @@ module.exports = function(RED) {
          * @param { "auto" | "client" | "client-individual" } clientAck Can be `auto`, `client` or `client-individual` (the latter only starting from STOMP v1.1)
          * @param { Function } callback 
          */
-        node.subscribe = function(queue, acknowledgement, callback) {
+        node.subscribe = function(queue, acknowledgment, callback) {
             node.log(`Subscribing to: ${queue}`);
 
             if (node.connected && !node.closing) {
@@ -297,7 +297,7 @@ module.exports = function(RED) {
                 const headers = {
                     id: node.subscriptionIds[queue],
                     // Only set client-individual if not v1.0
-                    ack: acknowledgement === "client-individual" && node.options.protocolVersion === "1.0" ? "client" : acknowledgement 
+                    ack: acknowledgment === "client-individual" && node.options.protocolVersion === "1.0" ? "client" : acknowledgment 
                 }
 
                 node.client.subscribe(queue, headers, function(body, responseHeaders) {
@@ -343,7 +343,7 @@ module.exports = function(RED) {
 
         /**
          * Acknowledge (a) message(s) that was received from the specified queue.
-         * @param {String} queue The queue/topic to send an acknowledgement for
+         * @param {String} queue The queue/topic to send an acknowledgment for
          * @param {String} messageId ID of the message that was received from the server, which can be found in the reponse header as `message-id`
          * @param {String} transaction Optional transaction name
          */
@@ -351,7 +351,7 @@ module.exports = function(RED) {
             if (node.connected && !node.closing) {
                 node.client.ack(messageId, node.subscriptionIds[queue], transaction);
             } else {
-                node.error("Can't send acknowledgement, not connected");
+                node.error("Can't send acknowledgment, not connected");
             }
         }
 

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -28,6 +28,8 @@ module.exports = function(RED) {
         RED.nodes.createNode(this,n);
         this.server = n.server;
         this.topic = n.topic;
+        this.enableSubscriptionId = n.enable_subscriptionid;
+        this.subscriptionid = n.subscriptionid;
 
         this.serverConfig = RED.nodes.getNode(this.server);
         this.stompClientOpts = {
@@ -44,7 +46,14 @@ module.exports = function(RED) {
         if (this.serverConfig.vhost) {
             this.stompClientOpts.vhost = this.serverConfig.vhost;
         }
-        this.subscribeHeaders = this.serverConfig.ack ? { "ack": "client" } : {};
+
+        this.subscribeHeaders = {};
+        if (this.enableSubscriptionId) {
+            this.subscribeHeaders.id = this.subscriptionid;
+        }
+        if (this.serverConfig.ack) {
+            this.subscribeHeaders.ack = "client";
+        }
 
         var node = this;
         var msg = {topic:this.topic};

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -4,20 +4,245 @@ module.exports = function(RED) {
     var StompClient = require('stomp-client');
     var querystring = require('querystring');
 
+    // ----------------------------------------------
+    // ------------------- State --------------------
+    // ----------------------------------------------
+    function updateStatus(node, allNodes) {
+        let setStatus = setStatusDisconnected;
+
+        if (node.connecting) {
+            setStatus = setStatusConnecting;
+        } else if (node.connected) {
+            setStatus = setStatusConnected;
+        }
+
+        setStatus(node, allNodes);
+    }
+
+    function setStatusDisconnected(node, allNodes) {
+        if (allNodes) {
+            for (let id in node.users) {
+                if (hasProperty(node.users, id)) {
+                    node.users[id].status({ fill: "red", shape: "ring", text: "node-red:common.status.disconnected"});
+                }
+            }
+        } else {
+            node.status({ fill: "red", shape: "ring", text: "node-red:common.status.disconnected" })
+        }
+    }
+
+    function setStatusConnecting(node, allNodes) {
+        if(allNodes) {
+            for (var id in node.users) {
+                if (hasProperty(node.users, id)) {
+                    node.users[id].status({ fill: "yellow", shape: "ring", text: "node-red:common.status.connecting" });
+                }
+            }
+        } else {
+            node.status({ fill: "yellow", shape: "ring", text: "node-red:common.status.connecting" });
+        }
+    }
+
+    function setStatusConnected(node, allNodes) {
+        if(allNodes) {
+            for (var id in node.users) {
+                if (hasProperty(node.users, id)) {
+                    node.users[id].status({ fill: "green", shape: "dot", text: "node-red:common.status.connected" });
+                }
+            }
+        } else {
+            node.status({ fill: "green", shape: "dot", text: "node-red:common.status.connected" });
+        }
+    }
+
+    function setStatusError(node, allNodes) {
+        if(allNodes) {
+            for (var id in node.users) {
+                if (hasProperty(node.users, id)) {
+                    node.users[id].status({ fill: "red", shape: "dot", text: "error" });
+                }
+            }
+        } else {
+            node.status({ fill: "red", shape: "dot", text: "error" });
+        }
+    }
+
+    // ----------------------------------------------
+    // ---------------- Connection ------------------
+    // ----------------------------------------------
+    function handleConnectAction(node, msg, done) {
+        const clientOptions = typeof msg.clientOptions === 'object' ? msg.clientOptions : null;
+        if (clientOptions) {
+            if (!node.client) {
+                // Client has not been initialized - initialize client and connect
+                node.client = new StompClient(clientOptions);
+                node.client.connect(function(sessionId) {
+                    done(sessionId);
+                });
+            } else {
+                // Already connected/connecting/reconnecting
+                if (clientOptions.forceReconnect) {
+                    // The force flag tells us to cycle the connection
+                    node.client.disconnect(function() {
+                        node.client = new StompClient(clientOptions);
+                        node.client.connect(function(sessionId) {
+                            done(sessionId)
+                        })
+                    });
+                }
+            }
+        } else {
+            done(new Error("No connection options provided"));
+        }
+    }
+
+    function handleDisconnectAction(node, done) {
+        node.client.disconnect(function() {
+            done();
+        });
+    }
+
     function StompServerNode(n) {
         RED.nodes.createNode(this,n);
-        this.server = n.server;
-        this.port = n.port;
-        this.protocolversion = n.protocolversion;
-        this.ack = n.ack;
-        this.vhost = n.vhost;
-        this.reconnectretries = n.reconnectretries || 999999;
-        this.reconnectdelay = (n.reconnectdelay || 15) * 1000;
-        this.name = n.name;
-        this.clientConnection = n.clientConnection;
-        this.connected = n.connected;
-        this.username = this.credentials.user;
-        this.password = this.credentials.password;
+        const node = this;
+        // To keep track of processing nodes that use this config node for their connection
+        node.users = {};
+        // Config node state
+        node.connected = false;
+        node.connecting = false;
+        node.closing = false;
+        node.options = {};
+        // node.subscriptions = {};
+        node.sessionId = null;
+        /** @type {StompClient} */
+        node.client;
+        node.setOptions = function(options, init) {
+            if (!options || typeof options !== "object") {
+                return; // Nothing to change
+            }
+
+            // Apply property changes (only if the property exists in the options object)
+            setIfHasProperty(options, node, "address", init);
+            setIfHasProperty(options, node, "port", init);
+            setIfHasProperty(options, node, "protocolVersion", init);
+            setIfHasProperty(options, node, "clientAcknowledgement", init);
+            setIfHasProperty(options, node, "vhost", init);
+            setIfHasProperty(options, node, "reconnectRetries", init);
+            setIfHasProperty(options, node, "reconnectDelay", init);
+
+            if (node.credentials) {
+                node.username = node.credentials.username;
+                node.password = node.credentials.password;
+            }
+            if (!init && hasProperty(options, "username")) {
+                node.username = options.username;
+            }
+            if (!init && hasProperty(options, "password")) {
+                node.password = options.password;
+            }
+
+            // Build options for passing to the stomp-client API
+            node.options = {
+                address: node.address,
+                port: node.port * 1,
+                user: node.username,
+                pass: node.password,
+                protocolVersion: node.protocolVersion,
+                reconnectOpts: {
+                    retries: node.reconnectRetries * 1,
+                    delay: node.reconnectDelay * 1
+                }
+            };
+        }
+
+        node.setOptions(n, true);
+
+        // Define functions called by STOMP processing nodes
+        node.register = function(stompNode) {
+            node.users[stompNode.id] = stompNode;
+            // Auto connect when first STOMP processing node is added
+            if (Object.keys(node.users).length === 1) {
+                node.connect();
+                // Update nodes status
+                setTimeout(function() { updateStatus(node, true) }, 1);
+            }
+        }
+
+        node.deregister = function(stompNode, done, autoDisconnect) {
+            delete node.users[stompNode.id];
+            if (autoDisconnect && !node.closing && node.connected && Object.keys(node.users).length === 0) {
+                node.disconnect(done);
+            } else {
+                done();
+            }
+        }
+
+        node.canConnect = function() {
+            return !node.connected && !node.connecting;
+        }
+
+        node.connect = function(callback) {
+            if (node.canConnect()) {
+                node.closing = false;
+                node.connecting = true;
+                setStatusConnecting(node, true);
+
+                try {
+                    // Remove left over client if needed
+                    if (node.client) {
+                        node.client.disconnect();
+                        node.client = null;
+                    }
+
+                    node.client = new StompClient(node.options);
+                    node.client.connect(function(sessionId) {
+                        node.sessionId = sessionId;
+                    });
+                    
+                    node.client.on("connect", function() {
+                        node.closing = false;
+                        node.connecting = false;
+                        node.connected = true;
+                        if (typeof callback === "function") {
+                            callback();
+                        }
+
+                        node.log("Connected to STOMP server", {sessionId: node.sessionId, url: `${node.options.address}:${node.options.port}`, protocolVersion: node.options.protocolVersion});
+                        setStatusConnected(node, true);
+                    });
+                    
+                    node.client.on("reconnect", function(sessionId, numOfRetries) {
+                        node.connecting = false;
+                        node.connected = true;
+                        node.sessionId = sessionId;
+
+                        node.log("Reconnected to STOMP server", {sessionId: node.sessionId, url: `${node.options.address}:${node.options.port}`, protocolVersion: node.options.protocolVersion, retries: numOfRetries});
+                        setStatusConnected(node, true);
+                    });
+
+                    node.client.on("reconnecting", function() {
+                        node.warn("reconnecting");
+                        node.connecting = true;
+                        node.connected = false;
+
+                        node.log("Reconnecting to STOMP server...", {url: `${node.options.address}:${node.options.port}`, protocolVersion: node.options.protocolVersion});
+                        setStatusConnecting(node, true);
+                    });
+
+                    node.client.on("error", function(err) {
+                        node.error(err);
+                        setStatusError(node, true);
+                    });
+
+                } catch (err) {
+                    node.error(err);
+                }
+            }
+        }
+
+        node.disconnect = function(callback) {
+            
+        }
     }
     RED.nodes.registerType("stomp-server",StompServerNode,{
         credentials: {
@@ -283,3 +508,36 @@ module.exports = function(RED) {
     RED.nodes.registerType("stomp ack",StompAckNode);
 
 };
+
+
+// ----------------------------------------------
+// ----------------- Helpers --------------------
+// ----------------------------------------------
+    /**
+     * Helper function for applying changes to an objects properties ONLY when the src object actually has the property.
+     * This avoids setting a `dst` property null/undefined when the `src` object doesnt have the named property.
+     * @param {object} src Source object containing properties
+     * @param {object} dst Destination object to set property
+     * @param {string} propName The property name to set in the Destination object
+     * @param {boolean} force force the dst property to be updated/created even if src property is empty
+     */
+    function setIfHasProperty(src, dst, propName, force) {
+        if (src && dst && propName) {
+            const ok = force || hasProperty(src, propName);
+            if (ok) {
+                dst[propName] = src[propName];
+            }
+        }
+    }
+
+    /**
+     * Helper function to test an object has a property
+     * @param {object} obj Object to test
+     * @param {string} propName Name of property to find
+     * @returns true if object has property `propName`
+     */
+    function hasProperty(obj, propName) {
+        //JavaScript does not protect the property name hasOwnProperty
+        //Object.prototype.hasOwnProperty.call is the recommended/safer test
+        return Object.prototype.hasOwnProperty.call(obj, propName);
+    }

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -14,10 +14,10 @@ module.exports = function(RED) {
         this.reconnectretries = n.reconnectretries || 999999;
         this.reconnectdelay = (n.reconnectdelay || 15) * 1000;
         this.name = n.name;
+        this.clientConnection = n.clientConnection;
+        this.connected = n.connected;
         this.username = this.credentials.user;
         this.password = this.credentials.password;
-        this.clientConnection = null;
-        this.connected = false;
     }
     RED.nodes.registerType("stomp-server",StompServerNode,{
         credentials: {

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -119,7 +119,7 @@ module.exports = function(RED) {
                 protocolVersion: node.protocolVersion,
                 reconnectOpts: {
                     retries: node.reconnectRetries * 1,
-                    delay: node.reconnectDelay * 1
+                    delay: node.reconnectDelay * 1000
                 },
                 vhost: node.vhost
             };

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -57,6 +57,10 @@ module.exports = function(RED) {
             node.warn("reconnecting");
         });
 
+        node.client.on("reconnect", function() {
+            node.status({fill:"green",shape:"dot",text:"connected"});
+        });
+
         node.client.on("error", function(error) {
             node.status({fill:"grey",shape:"dot",text:"error"});
             node.warn(error);

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -128,6 +128,10 @@ module.exports = function(RED) {
             node.warn("reconnecting");
         });
 
+        node.client.on("reconnect", function() {
+            node.status({fill:"green",shape:"dot",text:"connected"});
+        });
+
         node.client.on("error", function(error) {
             node.status({fill:"grey",shape:"dot",text:"error"});
             node.warn(error);

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -410,6 +410,11 @@ module.exports = function(RED) {
 
             node.on("input", function(msg, send, done) {
                 if (node.topic && msg.payload) {
+                    try {
+                        msg.payload = JSON.stringify(msg.payload);
+                    } catch {
+                        msg.payload = `${msg.payload}`;
+                    }
                     node.serverConnection.publish(node.topic, msg.payload, msg.headers || {});
                     done();
                 }

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -252,6 +252,7 @@ module.exports = function(RED) {
                 // Disconnection already in progress or not connected
                 callback();
             } else {
+                node.log('Disconnecting from STOMP server...');
                 waitDisconnect(node.client, 2000).then(() => {
                     node.log("Disconnected from STOMP server", {sessionId: node.sessionId, url: `${node.options.address}:${node.options.port}`, protocolVersion: node.options.protocolVersion})
                 }).catch(() => {
@@ -338,7 +339,6 @@ module.exports = function(RED) {
         }
 
         node.on("close", function(done) {
-            node.log('Disconnecting...');
             node.disconnect(function() { done (); });
         });
     }

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -221,7 +221,7 @@ module.exports = function(RED) {
             });
 
             node.on("input", function(msg) {
-                node.ack(msg.messageId, msg.subsriptionId, msg.transaction);
+                node.client.ack(msg.messageId, msg.subsriptionId, msg.transaction);
             });
 
             node.on("close", function(done) {

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -336,9 +336,9 @@ module.exports = function(RED) {
 
         node.ack = function(queue, messageId, transaction = undefined) {
             if (node.connected) {
-                node.client.ack(messageId, subscriptionIds[queue], transaction);
+                node.client.ack(messageId, node.subscriptionIds[queue], transaction);
             } else {
-                node.error("Can't publish, not connected");
+                node.error("Can't send acknowledgement, not connected");
             }
         }
 

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -101,7 +101,7 @@ module.exports = function(RED) {
             });
         }
 
-        if (!node.server.connected) {
+        if (!node.serverConfig.connected) {
             node.status({fill:"grey",shape:"ring",text:"connecting"});
             node.client.connect(function(sessionId) {
                 node.serverConfig.connected = true;


### PR DESCRIPTION
## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes
I did a refactor of the STOMP nodes to be in accordance with the default Node-Red MQTT nodes as the connection is handled in a better way (shared for all nodes using the same config node). In the current version of the STOMP nodes each node creates its own connection which causes unneeded overhead (and confusion when managing connections on the server).  

Additionally a node for sending client Acknowledgments was added. This enables us to keep messages in the queue until the handling was successful on the client side.

Partly fix: https://github.com/node-red/node-red-nodes/issues/143
NACK is currently not implemented as I don't really see a use case for it (I don't find a detailed explanation about it, from my findings the server controls what happend on NACK)

Is it plausible to make this a V1.0.0 release for the STOMP node or when will it reach V1?

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
