### PR TITLE
Bugfix all sense channels

### DIFF
--- a/hardware/sensehat/sensehat.py
+++ b/hardware/sensehat/sensehat.py
@@ -66,7 +66,7 @@ hf_interval = 0.09 # Approx 10/s
 lf_interval = 1
 
 hf_enabled = False
-lf_enabled = False
+lf_enabled = True
 
 scroll = None
 

--- a/hardware/sensehat/sensehat.py
+++ b/hardware/sensehat/sensehat.py
@@ -66,7 +66,7 @@ hf_interval = 0.09 # Approx 10/s
 lf_interval = 1
 
 hf_enabled = False
-lf_enabled = True
+lf_enabled = True 
 
 scroll = None
 


### PR DESCRIPTION
Hello,

this pull request fixes a small bug that avoids reading envrioment and motion group at the same time. Without the bugfix it is only possible to read one.

The bug is discussed here:
https://discourse.nodered.org/t/not-possible-to-read-all-values-in-sensehat-node/78052/13

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)


## Proposed changes

One has to set **lf_enabled = False** to **lf_enabled = True**. This enables the reading of both in the global process command. 

