### PR TITLE
STOMP bugfix: msg.topic can't be used with STOMP out node and ack node

### DIFF
--- a/io/stomp/18-stomp.html
+++ b/io/stomp/18-stomp.html
@@ -197,6 +197,7 @@
     <p>
         The node allows for following inputs:
         <ul>
+            <li><code>msg.topic</code>The topic to which the message should be acknowledged, if the <b>Destionation</b> field is set the msg.topic will be overwritten by this value</li>
             <li><code>msg.messageId</code>: The id of the message to acknowledge</li>
             <li><code>msg.transaction</code>: Optional transaction name</li>
         </ul>

--- a/io/stomp/18-stomp.html
+++ b/io/stomp/18-stomp.html
@@ -197,7 +197,7 @@
     <p>
         The node allows for following inputs:
         <ul>
-            <li><code>msg.topic</code>The topic to which the message should be acknowledged, if the <b>Destionation</b> field is set the msg.topic will be overwritten by this value</li>
+            <li><code>msg.topic</code>The topic for which the message should be acknowledged, if the <b>Destination</b> field is set the msg.topic will be overwritten by this value</li>
             <li><code>msg.messageId</code>: The id of the message to acknowledge</li>
             <li><code>msg.transaction</code>: Optional transaction name</li>
         </ul>

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -420,7 +420,7 @@ module.exports = function(RED) {
             setStatusDisconnected(node);
 
             node.on("input", function(msg, send, done) {
-                const topic = msg.topic || node.topic;
+                const topic = node.topic || msg.topic;
                 if (topic.length > 0 && msg.payload) {
                     try {
                         msg.payload = JSON.stringify(msg.payload);
@@ -469,7 +469,7 @@ module.exports = function(RED) {
             setStatusDisconnected(node);
 
             node.on("input", function(msg, send, done) {
-                const topic = msg.topic || node.topic;
+                const topic = node.topic || msg.topic;
                 if (topic.length > 0) {
                     node.serverConnection.ack(topic, msg.messageId, msg.transaction);
                 } else if (!topic.length > 0) {

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -420,15 +420,21 @@ module.exports = function(RED) {
             setStatusDisconnected(node);
 
             node.on("input", function(msg, send, done) {
-                if (node.topic && msg.payload) {
+                const topic = msg.topic || node.topic;
+                if (topic.length > 0 && msg.payload) {
                     try {
                         msg.payload = JSON.stringify(msg.payload);
                     } catch {
                         msg.payload = `${msg.payload}`;
                     }
                     node.serverConnection.publish(node.topic, msg.payload, msg.headers || {});
-                    done();
+                } else if (!topic.length > 0) {
+                    node.warn('No valid publish topic');
+
+                } else {
+                    node.warn('Payload is undefined or null')
                 }
+                done();
             });
 
             node.serverConnection.register(node);

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -427,12 +427,12 @@ module.exports = function(RED) {
                     } catch {
                         msg.payload = `${msg.payload}`;
                     }
-                    node.serverConnection.publish(node.topic, msg.payload, msg.headers || {});
+                    node.serverConnection.publish(topic, msg.payload, msg.headers || {});
                 } else if (!topic.length > 0) {
                     node.warn('No valid publish topic');
 
                 } else {
-                    node.warn('Payload is undefined or null')
+                    node.warn('Payload or topic is undefined/null')
                 }
                 done();
             });
@@ -469,7 +469,15 @@ module.exports = function(RED) {
             setStatusDisconnected(node);
 
             node.on("input", function(msg, send, done) {
-                node.serverConnection.ack(node.topic, msg.messageId, msg.transaction);
+                const topic = msg.topic || node.topic;
+                if (topic.length > 0) {
+                    node.serverConnection.ack(topic, msg.messageId, msg.transaction);
+                } else if (!topic.length > 0) {
+                    node.warn('No valid publish topic');
+
+                } else {
+                    node.warn('Payload or topic is undefined/null')
+                }
                 done();
             });
 


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.-->

## Types of changes
Fixes: https://github.com/node-red/node-red-nodes/issues/1008
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
Make it possible to provide msg.topic, to a STOMP node but give prio to the "Destination" field of the node itself (just like it was before v1)
<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
