### PR TITLE
Support stop msg for daemon node

### DIFF
--- a/utility/daemon/README.md
+++ b/utility/daemon/README.md
@@ -34,7 +34,7 @@ to restart the command automatically.
 
 Setting `msg.kill` to a signal name (e.g. SIGINT, SIGHUP) will stop the process - but if the restart flag is set it will then auto restart.
 
-Sending `msg.start` will also re-start the process. Additional arguments can be specified in `msg.args`.
+Sending `msg.start` will start the process, if not already running. Additional arguments can be specified in `msg.args`.
 
 Sending `msg.stop` will stop the process and prevent automatic re-start until reset with `msg.start`.
 

--- a/utility/daemon/README.md
+++ b/utility/daemon/README.md
@@ -36,6 +36,8 @@ Setting `msg.kill` to a signal name (e.g. SIGINT, SIGHUP) will stop the process 
 
 Sending `msg.start` will also re-start the process. Additional arguments can be specified in `msg.args`.
 
+Sending `msg.stop` will stop the process and prevent automatic re-start until reset with `msg.start`.
+
 **Note:** Some applications will automatically buffer lines of output. It is advisable to turn off this behaviour.
 For example, if running a Python app, the `-u` parameter will stop the output being buffered.
 

--- a/utility/daemon/daemon.js
+++ b/utility/daemon/daemon.js
@@ -34,7 +34,7 @@ module.exports = function(RED) {
         function inputlistener(msg) {
             if (msg != null) {
                 if (msg.hasOwnProperty("stop")) {
-                    this.stopped = true;
+                    node.stopped = true;
                     if (node.running) {
                         node.child.kill(node.closer);
                     }
@@ -46,7 +46,7 @@ module.exports = function(RED) {
                     node.child.kill(msg.kill.toUpperCase());
                 }
                 else if (msg.hasOwnProperty("start")) {
-                    this.stopped = false;
+                    node.stopped = false;
                     if (!node.running) {
                         let args = "";
                         if (msg.hasOwnProperty("args") && msg.args.length > 0) {

--- a/utility/daemon/daemon.js
+++ b/utility/daemon/daemon.js
@@ -38,7 +38,6 @@ module.exports = function(RED) {
                     if (node.running) {
                         node.child.kill(node.closer);
                     }
-                    node.debug(node.cmd+" stopped by msg");
                     node.status({fill:"grey",shape:"ring",text:RED._("daemon.status.stopped")});
                 }
                 else if (msg.hasOwnProperty("kill") && node.running) {
@@ -46,17 +45,14 @@ module.exports = function(RED) {
                     node.child.kill(msg.kill.toUpperCase());
                 }
                 else if (msg.hasOwnProperty("start")) {
-                    node.stopped = false;
                     if (!node.running) {
                         let args = "";
                         if (msg.hasOwnProperty("args") && msg.args.length > 0) {
                             args = parseArgs(msg.args.trim());
                         }
                         runit(args);
-                    } else {
-                        node.child.kill(node.closer);
-                        // should this also re-start the process incase redo is not set XXX
                     }
+                    node.stopped = false;
                 }
                 else {
                     if (!Buffer.isBuffer(msg.payload)) {

--- a/utility/daemon/daemon.js
+++ b/utility/daemon/daemon.js
@@ -12,6 +12,7 @@ module.exports = function(RED) {
         this.op = n.op;
         this.redo = n.redo;
         this.running = false;
+        this.stopped = false;
         this.closer = n.closer || "SIGKILL";
         this.autorun = true;
         if (n.autorun === false) { this.autorun = false; }
@@ -32,16 +33,29 @@ module.exports = function(RED) {
 
         function inputlistener(msg) {
             if (msg != null) {
-                if (msg.hasOwnProperty("kill") && node.running) {
+                if (msg.hasOwnProperty("stop")) {
+                    this.stopped = true;
+                    if (node.running) {
+                        node.child.kill("SIGINT");
+                    }
+                    node.debug(node.cmd+" stopped by msg");
+                    node.status({fill:"grey",shape:"ring",text:RED._("daemon.status.stopped")});
+                }
+                else if (msg.hasOwnProperty("kill") && node.running) {
                     if (typeof msg.kill !== "string" || msg.kill.length === 0 || !msg.kill.toUpperCase().startsWith("SIG") ) { msg.kill = "SIGINT"; }
                     node.child.kill(msg.kill.toUpperCase());
                 }
-                else if (msg.hasOwnProperty("start") && !node.running) {
-                    let args = "";
-                    if (msg.hasOwnProperty("args") && msg.args.length > 0) {
-                        args = parseArgs(msg.args.trim());
+                else if (msg.hasOwnProperty("start")) {
+                    this.stopped = false;
+                    if (!node.running) {
+                        let args = "";
+                        if (msg.hasOwnProperty("args") && msg.args.length > 0) {
+                            args = parseArgs(msg.args.trim());
+                        }
+                        runit(args);
+                    } else {
+                        node.child.kill("SIGINT");
                     }
-                    runit(args);
                 }
                 else {
                     if (!Buffer.isBuffer(msg.payload)) {
@@ -111,7 +125,8 @@ module.exports = function(RED) {
                     var rc = code;
                     if (code === null) { rc = signal; }
                     node.send([null,null,{payload:rc}]);
-                    node.status({fill:"red",shape:"ring",text:RED._("daemon.status.stopped")});
+                    const color = node.stopped ? "grey" : "red";
+                    node.status({fill:color,shape:"ring",text:RED._("daemon.status.stopped")});
                 });
 
                 node.child.on('error', function (err) {
@@ -138,7 +153,7 @@ module.exports = function(RED) {
 
         if (node.redo === true) {
             var loop = setInterval( function() {
-                if (!node.running) {
+                if (!node.running && !node.stopped) {
                     node.warn(RED._("daemon.errors.restarting") + " : " + node.cmd);
                     runit();
                 }

--- a/utility/daemon/daemon.js
+++ b/utility/daemon/daemon.js
@@ -36,7 +36,7 @@ module.exports = function(RED) {
                 if (msg.hasOwnProperty("stop")) {
                     this.stopped = true;
                     if (node.running) {
-                        node.child.kill("SIGINT");
+                        node.child.kill(node.closer);
                     }
                     node.debug(node.cmd+" stopped by msg");
                     node.status({fill:"grey",shape:"ring",text:RED._("daemon.status.stopped")});
@@ -54,7 +54,8 @@ module.exports = function(RED) {
                         }
                         runit(args);
                     } else {
-                        node.child.kill("SIGINT");
+                        node.child.kill(node.closer);
+                        // should this also re-start the process incase redo is not set XXX
                     }
                 }
                 else {


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

This PR adds support to the node-red-node-daemon for a stop message. When stopped the process will be terminated as per the configured signal and will not be restarted by redo until re-set via a subsequent start message. 

Documentation updated on start message to indicate it will not restart a running process


- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
