### PR TITLE
STOMP: Improved error stated and logging

### DIFF
--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -219,11 +219,10 @@ module.exports = function(RED) {
                     });
 
                     node.client.on("reconnecting", function() {
-                        node.warn("Reconnecting to STOMP server");
                         node.connecting = true;
                         node.connected = false;
 
-                        node.log(`Reconnecting to STOMP server, url: ${node.options.address}:${node.options.port}, protocolVersion: ${node.options.protocolVersion}`);
+                        node.warn(`Reconnecting to STOMP server, url: ${node.options.address}:${node.options.port}, protocolVersion: ${node.options.protocolVersion}`);
                         setStatusConnecting(node, true);
                     });
 

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -230,14 +230,14 @@ module.exports = function(RED) {
                     node.client.on("error", function(err) {
                         node.error(err);
                         if (err.reconnectionFailed) {
-                            setStatusError(node, true);
+                            setStatusError(node, true, "Reconnection failed: exceeded number of reconnection attempts");
                         }
                     });
 
                     node.client.connect();
                 } catch (err) {
                     node.error(err);
-                    setStatusError(node, true, "Reconnection failed: exceeded number of reconnection attempts");
+                    setStatusError(node, true);
                 }
             } else {
                 node.log("Not connecting to STOMP server, already connected");

--- a/io/stomp/18-stomp.js
+++ b/io/stomp/18-stomp.js
@@ -54,15 +54,15 @@ module.exports = function(RED) {
         }
     }
 
-    function setStatusError(node, allNodes) {
+    function setStatusError(node, allNodes, message = undefined) {
         if(allNodes) {
             for (var id in node.users) {
                 if (hasProperty(node.users, id)) {
-                    node.users[id].status({ fill: "red", shape: "dot", text: "error" });
+                    node.users[id].status({ fill: "red", shape: "dot", text: message ?? "error" });
                 }
             }
         } else {
-            node.status({ fill: "red", shape: "dot", text: "error" });
+            node.status({ fill: "red", shape: "dot", text: message ?? "error" });
         }
     }
 
@@ -219,22 +219,25 @@ module.exports = function(RED) {
                     });
 
                     node.client.on("reconnecting", function() {
-                        node.warn("reconnecting");
+                        node.warn("Reconnecting to STOMP server");
                         node.connecting = true;
                         node.connected = false;
 
-                        node.log("Reconnecting to STOMP server...", {url: `${node.options.address}:${node.options.port}`, protocolVersion: node.options.protocolVersion});
+                        node.log(`Reconnecting to STOMP server, url: ${node.options.address}:${node.options.port}, protocolVersion: ${node.options.protocolVersion}`);
                         setStatusConnecting(node, true);
                     });
 
                     node.client.on("error", function(err) {
                         node.error(err);
-                        setStatusError(node, true);
+                        if (err.reconnectionFailed) {
+                            setStatusError(node, true);
+                        }
                     });
 
                     node.client.connect();
                 } catch (err) {
                     node.error(err);
+                    setStatusError(node, true, "Reconnection failed: exceeded number of reconnection attempts");
                 }
             } else {
                 node.log("Not connecting to STOMP server, already connected");


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Adds better reflection of the connection status using the status of the STOMP nodes. Currently all nodes will have an error state which doesn't reset after any error occurs. With this update this will only happen when the client is disconnected from the STOM server. If another error occurs only a message is logged but the connection state is not changed as the client is still connected to the server.

An example: "unexpected ACK message from client".
This error occurs when you send an ACK message to the server without setting up the correct acknowledgement mode on subscription. 
-> no need to set an error state across all STOMP nodes, logging this error (also in debug window) is sufficient as this is no connection issue which leads to other nodes failing. 

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
