### PR TITLE
simpleParser takes an optional parameter checksumAlgo. Specify the …

### DIFF
--- a/social/email/61-email.js
+++ b/social/email/61-email.js
@@ -333,7 +333,7 @@ module.exports = function(RED) {
                     try {
                         // We have now received a new email message.  Create an instance of a mail parser
                         // and pass in the email message.  The parser will signal when it has parsed the message.
-                        simpleParser(nextMessage, {}, function(err, parsed) {
+                        simpleParser(nextMessage, {checksumAlgo: 'sha256'}, function(err, parsed) {
                             //node.log(util.format("simpleParser: on(end): %j", mailObject));
                             if (err) {
                                 node.status({fill:"red", shape:"ring", text:"email.status.parseerror"});
@@ -493,7 +493,7 @@ module.exports = function(RED) {
                                             //console.log("> Fetch message - msg=%j, seqno=%d", imapMessage, seqno);
                                                 imapMessage.on('body', function(stream, info) {
                                                 //console.log("> message - body - stream=?, info=%j", info);
-                                                    simpleParser(stream, {}, function(err, parsed) {
+                                                    simpleParser(stream, {checksumAlgo: 'sha256'}, function(err, parsed) {
                                                         if (err) {
                                                             node.status({fill:"red", shape:"ring", text:"email.status.parseerror"});
                                                             node.error(RED._("email.errors.parsefail", {folder:node.box}),err);
@@ -643,7 +643,7 @@ module.exports = function(RED) {
         }
 
         node.options.onData = function (stream, session, callback) {
-            simpleParser(stream, { skipTextToHtml:true, skipTextLinks:true }, (err, parsed) => {
+            simpleParser(stream, { skipTextToHtml:true, skipTextLinks:true, checksumAlgo:'sha256' }, (err, parsed) => {
                 if (err) { node.error(RED._("email.errors.parsefail"),err); }
                 else {
                     node.status({fill:"green", shape:"dot", text:""});


### PR DESCRIPTION
…FIPS compliant sha256 hash algorithm here so that it will be used instead of the default of md5.

node-red: v3.1.5
node: v18.18.2
OS: Rocky Linux 9.3.
npm v9.8.1
node-red-node-email v2.1.0

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Allows node-red-node-email node to correctly work when FIPS crypto policy has been enabled on the operating system by setting the checksumAlgo for simpleParser to SHA256 which is FIPS compliant.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
