### PR TITLE
Add test for Pi4/5 to some of the Pi specific nodes in the hardware group

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ Put an `x` in the boxes that apply
 -->
 
 - [ ] Bugfix (non-breaking change which fixes an issue)
-- [x] New feature (non-breaking change which adds functionality)
+- [ ] New feature (non-breaking change which adds functionality)
 
 <!--
 If you want to raise a pull-request with a new feature, or a refactoring
@@ -25,13 +25,10 @@ the [forum](https://discourse.nodered.org) or
 
 <!-- Describe the nature of this change. What problem does it address? -->
 
-Adds authentication option to the Email node (node-red-node-email) to use OAuth and XOAuth2
-********** This version: IMAP ONLY **********
-
 ## Checklist
 <!-- Put an `x` in the boxes that apply -->
 
-- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
-- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
-- [x] I have run `grunt` to verify the unit tests pass
-- [x] I have added suitable unit tests to cover the new/changed functionality
+- [ ] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
+- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
+- [ ] I have run `grunt` to verify the unit tests pass
+- [ ] I have added suitable unit tests to cover the new/changed functionality

--- a/hardware/LEDborg/78-ledborg.js
+++ b/hardware/LEDborg/78-ledborg.js
@@ -12,7 +12,7 @@ module.exports = function(RED) {
 
     try {
         var cpuinfo = fs.readFileSync("/proc/cpuinfo").toString();
-        if (cpuinfo.indexOf(": BCM") === -1) {
+        if (cpuinfo.indexOf(": BCM") === -1 && cpuinfo.indexOf(": Raspberry Pi")) {
             RED.log.warn("ledborg : "+RED._("node-red:rpi-gpio.errors.ignorenode"));
             allOK = false;
         }

--- a/hardware/LEDborg/78-ledborg.js
+++ b/hardware/LEDborg/78-ledborg.js
@@ -12,7 +12,7 @@ module.exports = function(RED) {
 
     try {
         var cpuinfo = fs.readFileSync("/proc/cpuinfo").toString();
-        if (cpuinfo.indexOf(": BCM") === -1 && cpuinfo.indexOf(": Raspberry Pi")) {
+        if (cpuinfo.indexOf(": BCM") === -1 && cpuinfo.indexOf(": Raspberry Pi") === -1) {
             RED.log.warn("ledborg : "+RED._("node-red:rpi-gpio.errors.ignorenode"));
             allOK = false;
         }

--- a/hardware/PiLcd/pilcd.js
+++ b/hardware/PiLcd/pilcd.js
@@ -10,7 +10,7 @@ module.exports = function(RED) {
 
     try {
         var cpuinfo = fs.readFileSync("/proc/cpuinfo").toString();
-        if (cpuinfo.indexOf(": BCM") === -1 && cpuinfo.indexOf(": Raspberry Pi")) {
+        if (cpuinfo.indexOf(": BCM") === -1 && cpuinfo.indexOf(": Raspberry Pi") === -1) {
             RED.log.warn("rpi-lcd : "+RED._("pilcd.errors.ignorenode"));
             allOK = false;
         }

--- a/hardware/PiLcd/pilcd.js
+++ b/hardware/PiLcd/pilcd.js
@@ -10,7 +10,7 @@ module.exports = function(RED) {
 
     try {
         var cpuinfo = fs.readFileSync("/proc/cpuinfo").toString();
-        if (cpuinfo.indexOf(": BCM") === -1) {
+        if (cpuinfo.indexOf(": BCM") === -1 && cpuinfo.indexOf(": Raspberry Pi")) {
             RED.log.warn("rpi-lcd : "+RED._("pilcd.errors.ignorenode"));
             allOK = false;
         }

--- a/hardware/PiSrf/pisrf.js
+++ b/hardware/PiSrf/pisrf.js
@@ -10,7 +10,7 @@ module.exports = function(RED) {
 
     try {
         var cpuinfo = fs.readFileSync("/proc/cpuinfo").toString();
-        if (cpuinfo.indexOf(": BCM") === -1 && cpuinfo.indexOf(": Raspberry Pi")) {
+        if (cpuinfo.indexOf(": BCM") === -1 && cpuinfo.indexOf(": Raspberry Pi") === -1) {
             RED.log.warn("rpi-srf : "+RED._("node-red:rpi-gpio.errors.ignorenode"));
             allOK = false;
         }

--- a/hardware/PiSrf/pisrf.js
+++ b/hardware/PiSrf/pisrf.js
@@ -10,7 +10,7 @@ module.exports = function(RED) {
 
     try {
         var cpuinfo = fs.readFileSync("/proc/cpuinfo").toString();
-        if (cpuinfo.indexOf(": BCM") === -1) {
+        if (cpuinfo.indexOf(": BCM") === -1 && cpuinfo.indexOf(": Raspberry Pi")) {
             RED.log.warn("rpi-srf : "+RED._("node-red:rpi-gpio.errors.ignorenode"));
             allOK = false;
         }

--- a/hardware/mcp3008/pimcp3008.js
+++ b/hardware/mcp3008/pimcp3008.js
@@ -7,7 +7,7 @@ module.exports = function(RED) {
     // unlikely if not on a Pi
     try {
         var cpuinfo = fs.readFileSync("/proc/cpuinfo").toString();
-        if (cpuinfo.indexOf(": BCM") === -1) {
+        if (cpuinfo.indexOf(": BCM") === -1 && cpuinfo.indexOf(": Raspberry Pi")) {
             RED.log.warn("Info : mcp3xxx : Not running on a Pi - Ignoring node");
         }
         else {

--- a/hardware/mcp3008/pimcp3008.js
+++ b/hardware/mcp3008/pimcp3008.js
@@ -7,7 +7,7 @@ module.exports = function(RED) {
     // unlikely if not on a Pi
     try {
         var cpuinfo = fs.readFileSync("/proc/cpuinfo").toString();
-        if (cpuinfo.indexOf(": BCM") === -1 && cpuinfo.indexOf(": Raspberry Pi")) {
+        if (cpuinfo.indexOf(": BCM") === -1 && cpuinfo.indexOf(": Raspberry Pi") === -1) {
             RED.log.warn("Info : mcp3xxx : Not running on a Pi - Ignoring node");
         }
         else {

--- a/hardware/unicorn/unicorn.js
+++ b/hardware/unicorn/unicorn.js
@@ -11,7 +11,7 @@ module.exports = function(RED) {
 
     try {
         var cpuinfo = fs.readFileSync("/proc/cpuinfo").toString();
-        if (cpuinfo.indexOf(": BCM") === -1) {
+        if (cpuinfo.indexOf(": BCM") === -1 && cpuinfo.indexOf(": Raspberry Pi")) {
             RED.log.warn("rpi-unicorn : "+RED._("node-red:rpi-gpio.errors.ignorenode"));
             allOK = false;
         }

--- a/hardware/unicorn/unicorn.js
+++ b/hardware/unicorn/unicorn.js
@@ -11,7 +11,7 @@ module.exports = function(RED) {
 
     try {
         var cpuinfo = fs.readFileSync("/proc/cpuinfo").toString();
-        if (cpuinfo.indexOf(": BCM") === -1 && cpuinfo.indexOf(": Raspberry Pi")) {
+        if (cpuinfo.indexOf(": BCM") === -1 && cpuinfo.indexOf(": Raspberry Pi") === -1) {
             RED.log.warn("rpi-unicorn : "+RED._("node-red:rpi-gpio.errors.ignorenode"));
             allOK = false;
         }


### PR DESCRIPTION
fixes #1073 
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Add test for `: Raspberry Pi` in `/proc/cpuinfo` to pick up Pi 4 and Pi 5


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
