### PR TITLE
suncalc msg at startup

### DIFF
--- a/time/suncalc/79-suncalc.html
+++ b/time/suncalc/79-suncalc.html
@@ -39,6 +39,11 @@
         <span style="margin-right:4px" data-i18n="sunrise.start"></span> <input type="text" id="node-input-soff" placeholder="minutes" style='width:60px;' > <span data-i18n="sunrise.mins"></span>
         <span style="margin-left:14px; margin-right:4px" data-i18n="sunrise.end"></span> <input type="text" id="node-input-eoff" placeholder="minutes" style='width:60px;'><span data-i18n="sunrise.mins"></span>
     </div>
+    <div class="form-row">
+        <label for="node-input-sendAtStartup"><i class="fa fa-refresh"></i><span data-i18n="sunrise.label.startup"></span></label>
+        <input type="checkbox" id="node-input-sendAtStartup" style='width:auto ;border:none; vertical-align:baseline;'>
+        <span for="node-input-sendAtStartup" data-i18n="sunrise.sendAtStartup"></span>
+    </div>
 </script>
 
 <script type="text/javascript">
@@ -53,6 +58,7 @@
             end: {value:"sunset", required:true},
             soff: {value:0, validate:RED.validators.number()},
             eoff: {value:0, validate:RED.validators.number()},
+            sendAtStartup: {value:false}
         },
         inputs:0,
         outputs:2,

--- a/time/suncalc/79-suncalc.js
+++ b/time/suncalc/79-suncalc.js
@@ -11,6 +11,7 @@ module.exports = function(RED) {
         this.end = n.end;
         this.soff = (n.soff || 0) * 60000;  // minutes
         this.eoff = (n.eoff || 0) * 60000;  // minutes
+        this.sendAtStartup = n.sendAtStartup;
 
         var node = this;
         var oldval = null;
@@ -48,7 +49,7 @@ module.exports = function(RED) {
             sun.azimuth = sun.azimuth * 180 / Math.PI;
             var msg = {payload:0, topic:"sun", sun:sun, moon:moon, start:s1, end:s2, now:now};
             if ((e1 > 0) & (e2 < 0)) { msg.payload = 1; }
-            if (oldval == null) { oldval = msg.payload; }
+            if (oldval == null && !node.sendAtStartup) { oldval = msg.payload; }
             if (msg.payload == 1) { node.status({fill:"yellow",shape:"dot",text:"sunrise.dayState"}); }
             else { node.status({fill:"blue",shape:"dot",text:"sunrise.nightState"}); }
             if (msg.payload != oldval) {

--- a/time/suncalc/locales/en-US/79-suncalc.html
+++ b/time/suncalc/locales/en-US/79-suncalc.html
@@ -4,7 +4,8 @@
     <p>Several choices of definition of sunrise and sunset are available, see the <i><a href = "https://github.com/mourner/suncalc" target="_new">suncalc</a></i> module for details.</p>
     <p>The start and end times can be offset by a number of minutes before (minus) or after (plus) the chosen event time.</p>
     <p>The first output emits a <code>msg.payload</code> of <i>1</i> or <i>0</i> every minute depending if in between selected times or not.
-    The second output emits only on the transition between night to day (<i>-> 1</i>) or day to night (<i>-> 0</i>).</p>
+    The second output emits only on the transition between night to day (<i>-> 1</i>) or day to night (<i>-> 0</i>).
+    When the initial value at startup is required to be sent, that value will be emitted at the second output.</p>
     <p>It also outputs <code>msg.start</code>, <code>msg.end</code> and <code>msg.now</code> which are todays start and end times, with offsets applied, in ISO format, and the current ISO time.</p>
     <p><code>msg.sun</code> is an object containing the azimuth and altitude, in degrees, of the current sun position.</p>
     <p><code>msg.moon</code> is an object containing <thead></thead> position, phase, illumination and icon of the moon.</p>

--- a/time/suncalc/locales/en-US/79-suncalc.json
+++ b/time/suncalc/locales/en-US/79-suncalc.json
@@ -1,32 +1,34 @@
 { 
-    "sunrise": { 
-        "label": { 
-            "latitude": " Latitude", 
-            "longitude": " Longitude", 
+    "sunrise": {
+        "label": {
+            "latitude": " Latitude",
+            "longitude": " Longitude",
             "start": " Start",
-			"end": " End",
-			"offset": " Offset",
-			"name": " Name"	
+            "end": " End",
+            "offset": " Offset",
+            "name": " Name",
+            "startup": " Startup"
         },
-		"nightEnd": "Morning astronomical twilight starts",
-		"nauticalDawn": "Morning nautical twilight starts",
-		"dawn": "Dawn, morning civil twilight starts",
-		"sunrise": "Sunrise",
-		"sunriseEnd": "Sunrise end",
-		"goldenHourEnd": "End of morning golden hour",	
-		"goldenHour": "Start of evening golden hour",
-		"sunsetStart": "Sunset start",
-		"sunset": "Sunset, civil twilight starts",
-		"dusk": "Dusk, Evening nautical twilight starts",
-		"nauticalDusk": "Evening astronomical twilight starts",
-		"night": "Dark enough for astronomy",
-		"start": " start",
-		"mins": " mins",
-		"end": " end",
-	    "dayState": "day",
-	    "nightState": "night",
-	    "onePerMin": "once per minute",
-	    "onse": "only on change",
-		"sunName": "Sun rise/set"
-    } 
+        "nightEnd": "Morning astronomical twilight starts",
+        "nauticalDawn": "Morning nautical twilight starts",
+        "dawn": "Dawn, morning civil twilight starts",
+        "sunrise": "Sunrise",
+        "sunriseEnd": "Sunrise end",
+        "goldenHourEnd": "End of morning golden hour",
+        "goldenHour": "Start of evening golden hour",
+        "sunsetStart": "Sunset start",
+        "sunset": "Sunset, civil twilight starts",
+        "dusk": "Dusk, Evening nautical twilight starts",
+        "nauticalDusk": "Evening astronomical twilight starts",
+        "night": "Dark enough for astronomy",
+        "start": " start",
+        "mins": " mins",
+        "end": " end",
+        "dayState": "day",
+        "nightState": "night",
+        "onePerMin": "once per minute",
+        "onse": "only on change",
+        "sunName": "Sun rise/set",
+        "sendAtStartup": "Send the current value at startup"
+    }
 }


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Proposed changes

As discussed on Discourse (see [here](https://discourse.nodered.org/t/pull-request-discussion-node-red-node-suncalc-send-msg-at-startup/91187/3)), I would like to get an output msg (at the second output) at startup to know whether it is day or night.

BTW the grunt tests failed at another node:

![image](https://github.com/user-attachments/assets/4ba77b14-1788-43c7-a08f-9b56e5d54873)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [X] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
