### PR TITLE
Update neopixel.js to fix detection of RPi CM4 with Bookworm

### DIFF
--- a/hardware/neopixel/neopixel.js
+++ b/hardware/neopixel/neopixel.js
@@ -10,7 +10,7 @@ module.exports = function(RED) {
 
     try {
         var cpuinfo = fs.readFileSync("/proc/cpuinfo").toString();
-        if (cpuinfo.indexOf(": BCM") === -1) {
+        if (cpuinfo.indexOf(": BCM") === -1 && cpuinfo.indexOf(": Raspberry Pi") === -1)) {
             RED.log.warn("rpi-neopixels : "+RED._("node-red:rpi-gpio.errors.ignorenode"));
             allOK = false;
         }


### PR DESCRIPTION
## Types of changes

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

My CM4 Module has in /proc/cpuinfo no " : BCM" text string
Wich leads to a false, failing Hardware check, and the NeoPixel nodes are ignored.

Instead of the "BCM" chip, /proc/cpuinfo shows "Hardware : Raspberry Pi Compute Module 4 Rev 1.1".  

The Check was updated to use ": BCM" or ": Raspberry Pi" to check for Raspberry Pi Hardware.


## Checklist

- [ x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
