### PR TITLE
Fix `cacheItemCount` to use `mtausers` length

### DIFF
--- a/social/email/61-email.html
+++ b/social/email/61-email.html
@@ -507,7 +507,7 @@
             // User Management
             let cacheItemCount = 0;
             if (node.mtausers && node.mtausers.length > 0) {
-                cacheItemCount = node.users.length;
+                cacheItemCount = node.mtausers.length;
                 node.mtausers.forEach(function (element, index, array) {
                     generateUserEntry(element, index);
                 });


### PR DESCRIPTION
## Types of changes


- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fix up missed missed change in 

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
