### PR TITLE
Markdown parser: add property selection

### DIFF
--- a/parsers/markdown/70-markdown.html
+++ b/parsers/markdown/70-markdown.html
@@ -1,12 +1,16 @@
 
-<script type="text/html" data-template-name="markdown">
+<script type="text/html" data-template-name="markdown-prop">
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
+    <div class="form-row">
+        <label for="node-input-property"><i class="fa fa-ellipsis-h"></i> <span data-i18n="node-red:common.label.property"></span></label>
+        <input type="text" id="node-input-property" style="width:70%;"/>
+    </div>
 </script>
 
-<script type="text/html" data-help-name="markdown">
+<script type="text/html" data-help-name="markdown-prop">
     <p>A function that converts the <code>msg.payload</code> in markdown format to html.</p>
     <p>If the input is a string it converts it to html.</p>
     <p>All other message types are ignored.</p>
@@ -17,20 +21,27 @@
 </script>
 
 <script type="text/javascript">
-    RED.nodes.registerType('markdown',{
+    RED.nodes.registerType('markdown-prop',{
         category: 'parser',
         color:"#DEBD5C",
         defaults: {
-            name: {value:""}
+            name: {value:""},
+            property: {value:"payload",required:true}
         },
         inputs:1,
         outputs:1,
         icon: "parser-markdown.png",
         label: function() {
-            return this.name||"markdown";
+            return this.name||("msg." + this.property)||"markdown";
         },
         labelStyle: function() {
             return this.name?"node_label_italic":"";
+        },
+        oneditprepare: function() {
+            if (this.property === undefined) {
+                $("#node-input-property").val("payload");
+            }
+            $("#node-input-property").typedInput({default:'msg',types:['msg']});
         }
     });
 </script>

--- a/parsers/markdown/70-markdown.html
+++ b/parsers/markdown/70-markdown.html
@@ -1,5 +1,5 @@
 
-<script type="text/html" data-template-name="markdown-prop">
+<script type="text/html" data-template-name="markdown">
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
@@ -10,7 +10,7 @@
     </div>
 </script>
 
-<script type="text/html" data-help-name="markdown-prop">
+<script type="text/html" data-help-name="markdown">
     <p>A function that converts the <code>msg.payload</code> in markdown format to html.</p>
     <p>If the input is a string it converts it to html.</p>
     <p>All other message types are ignored.</p>
@@ -21,7 +21,7 @@
 </script>
 
 <script type="text/javascript">
-    RED.nodes.registerType('markdown-prop',{
+    RED.nodes.registerType('markdown',{
         category: 'parser',
         color:"#DEBD5C",
         defaults: {

--- a/parsers/markdown/70-markdown.js
+++ b/parsers/markdown/70-markdown.js
@@ -3,15 +3,22 @@ module.exports = function(RED) {
     "use strict";
     var markdownNode = function(n) {
         var md = require('markdown-it')({html:true, linkify:true, typographer:true});
+
         RED.nodes.createNode(this,n);
+
+        this.property = n.property || "payload";
         var node = this;
-        //<div id="nr-markdown" style="font-family:helvetica neue,arial,helvetica,sans-serif; margin:12px">';
+
         node.on("input", function(msg) {
-            if (msg.payload !== undefined && typeof msg.payload === "string") {
-                msg.payload = md.render(msg.payload);
+            var value = RED.util.getMessageProperty(msg, node.property);
+
+            if (value !== undefined && typeof value === "string") {
+                RED.util.setMessageProperty(msg, node.property, md.render(value));
+                node.send(msg);
+            } else {
+                node.warn("No property value found");
             }
-            node.send(msg);
         });
     }
-    RED.nodes.registerType("markdown",markdownNode);
+    RED.nodes.registerType("markdown-prop",markdownNode);
 }

--- a/parsers/markdown/70-markdown.js
+++ b/parsers/markdown/70-markdown.js
@@ -20,5 +20,5 @@ module.exports = function(RED) {
             }
         });
     }
-    RED.nodes.registerType("markdown-prop",markdownNode);
+    RED.nodes.registerType("markdown",markdownNode);
 }

--- a/parsers/markdown/package.json
+++ b/parsers/markdown/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-node-markdown",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "description": "A Node-RED node to convert a markdown string to html.",
     "dependencies": {
         "markdown-it": "^14.1.0"


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Add a selection of which property contains the markdown. This is analogous to the base64 node that also allows selection of the property on the msg object to be converted.

This can be just as useful for the markdown node. Also there is no special JSONata or flow context handling in the setting of the property, only properties on the msg object are valid.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
