### PR TITLE
feat: add node-red-contrib-ventuz-osc nodes

### DIFF
--- a/io/ventuz-osc/.gitignore
+++ b/io/ventuz-osc/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+.DS_Store
+*.log
+npm-debug.log*
+.env
+.vscode/
+.idea/
+coverage/
+.nyc_output/

--- a/io/ventuz-osc/README.md
+++ b/io/ventuz-osc/README.md
@@ -1,0 +1,91 @@
+# node-red-contrib-ventuz-osc
+
+Node-RED 节点，用于 Ventuz OSC 通信。
+
+## 功能
+
+- **osc-out**: 发送 OSC 消息到 Ventuz（支持中文 BEUC 编码）
+- **osc-in**: 接收 Ventuz 广播的 OSC 消息
+
+## 特性
+
+- ✅ 完整的 OSC Bundle 支持
+- ✅ 中文字符串自动 BEUC 编码
+- ✅ 支持 int、float、string、blob 数据类型
+- ✅ 通配符地址过滤
+- ✅ 追踪发送方 IP/端口
+
+## 安装
+
+```bash
+cd ~/.node-red
+npm install node-red-contrib-ventuz-osc
+```
+
+或通过 Node-RED 管理面板搜索 `node-red-contrib-ventuz-osc` 安装。
+
+## 节点说明
+
+### osc-out 节点
+
+发送 OSC 消息到指定目标。
+
+**配置项：**
+- **host**: 目标主机地址（默认 127.0.0.1）
+- **port**: OSC 端口号（默认 9000）
+- **address**: OSC 地址（默认 /ventuz/broadcast）
+
+**输入消息格式：**
+```json
+{
+  "topic": "/ventuz/broadcast",
+  "payload": "Hello Ventuz"
+}
+```
+
+**支持的数据类型：**
+- 整数 (int32)
+- 浮点数 (float32)
+- 字符串 (UTF-8/BEUC)
+- 布尔值 (自动转 int)
+- Blob (Buffer)
+
+### osc-in 节点
+
+监听指定端口的 OSC 消息。
+
+**配置项：**
+- **port**: 监听端口号（默认 9001）
+- **address**: OSC 地址过滤器（默认 /ventuz/*）
+
+**输出消息格式：**
+```json
+{
+  "topic": "/ventuz/broadcast",
+  "payload": ["Hello", 123, 45.67],
+  "_ip": "192.168.1.100",
+  "_port": 12345,
+  "_raw": "<Buffer>"
+}
+```
+
+**地址过滤器示例：**
+- `/ventuz/*` - 匹配所有 /ventuz/ 开头的地址
+- `*` - 匹配所有地址
+- `/ventuz/broadcast` - 精确匹配
+
+## 示例
+
+导入 `examples/osc-example.json` 中的示例流程。
+
+## OSC 编码说明
+
+本模块的 OSC 编码实现参考了 [c3812600/osc](https://github.com/c3812600/osc) 项目，支持：
+
+- 标准 OSC 消息和 Bundle 格式
+- 中文字符串 BEUC 编码（自动检测）
+- 4 字节对齐填充
+
+## License
+
+MIT

--- a/io/ventuz-osc/examples/osc-example.json
+++ b/io/ventuz-osc/examples/osc-example.json
@@ -1,0 +1,84 @@
+[
+    {
+        "id": "osc-example-flow",
+        "type": "tab",
+        "label": "OSC Example",
+        "disabled": false,
+        "info": "示例流程：OSC 通信"
+    },
+    {
+        "id": "node-1",
+        "type": "osc-in",
+        "z": "osc-example-flow",
+        "name": "OSC In",
+        "port": "9001",
+        "address": "/ventuz/*",
+        "x": 150,
+        "y": 100,
+        "wires": [["node-2"]]
+    },
+    {
+        "id": "node-2",
+        "type": "debug",
+        "z": "osc-example-flow",
+        "name": "OSC Messages",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "payload",
+        "targetType": "msg",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 380,
+        "y": 100,
+        "wires": []
+    },
+    {
+        "id": "node-3",
+        "type": "inject",
+        "z": "osc-example-flow",
+        "name": "Send Test Message",
+        "props": [
+            {
+                "p": "payload"
+            },
+            {
+                "p": "topic",
+                "vt": "str"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "/ventuz/broadcast",
+        "payload": "Hello Ventuz!",
+        "payloadType": "str",
+        "x": 170,
+        "y": 200,
+        "wires": [["node-4"]]
+    },
+    {
+        "id": "node-4",
+        "type": "osc-out",
+        "z": "osc-example-flow",
+        "name": "OSC Out",
+        "host": "127.0.0.1",
+        "port": "9000",
+        "address": "/ventuz/broadcast",
+        "x": 400,
+        "y": 200,
+        "wires": [[]]
+    },
+    {
+        "id": "node-5",
+        "type": "comment",
+        "z": "osc-example-flow",
+        "name": "OSC 示例",
+        "info": "此示例演示如何使用 OSC 节点进行通信。\n\n1. OSC In 节点监听 OSC 消息\n2. OSC Out 节点发送 OSC 消息\n3. 使用 Inject 节点触发测试消息\n\n支持中文字符串（BEUC 编码）",
+        "x": 140,
+        "y": 40,
+        "wires": []
+    }
+]

--- a/io/ventuz-osc/index.js
+++ b/io/ventuz-osc/index.js
@@ -1,0 +1,9 @@
+/**
+ * node-red-contrib-ventuz-osc
+ * Node-RED nodes for Ventuz OSC communication
+ */
+
+module.exports = function(RED) {
+    RED.nodes.registerType("osc-out", require("./nodes/osc-out"));
+    RED.nodes.registerType("osc-in", require("./nodes/osc-in"));
+};

--- a/io/ventuz-osc/nodes/osc-in.html
+++ b/io/ventuz-osc/nodes/osc-in.html
@@ -1,0 +1,78 @@
+<script type="text/javascript">
+    RED.nodes.registerType('osc-in', {
+        category: 'network',
+        color: '#a6bbcf',
+        defaults: {
+            name: { value: "" },
+            port: { value: 9001, required: true, validator: RED.validators.number() },
+            address: { value: "/ventuz/*", required: true },
+            multicast: { value: "" },
+            iface: { value: "" }
+        },
+        inputs: 0,
+        outputs: 1,
+        icon: "bridge.svg",
+        label: function() {
+            return this.name || 'port ' + this.port;
+        },
+        paletteLabel: "osc in"
+    });
+</script>
+
+<script type="text/html" data-template-name="osc-in">
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+    <div class="form-row">
+        <label for="node-input-port"><i class="fa fa-plug"></i> Port</label>
+        <input type="text" id="node-input-port" placeholder="9001">
+    </div>
+    <div class="form-row">
+        <label for="node-input-address"><i class="fa fa-map-marker"></i> OSC Address Filter</label>
+        <input type="text" id="node-input-address" placeholder="/ventuz/*">
+    </div>
+    <div class="form-row">
+        <label for="node-input-multicast"><i class="fa fa-network-wired"></i> Multicast Group</label>
+        <input type="text" id="node-input-multicast" placeholder="230.230.230.235 (可选)">
+    </div>
+    <div class="form-row">
+        <label for="node-input-iface"><i class="fa fa-server"></i> Interface IP</label>
+        <input type="text" id="node-input-iface" placeholder="0.0.0.0 (可选)">
+    </div>
+</script>
+
+<script type="text/html" data-help-name="osc-in">
+    <p>OSC In 节点 - 接收 OSC 消息</p>
+    <h3>Outputs</h3>
+    <dl class="message-properties">
+        <dt>payload <span class="property-type">array</span></dt>
+        <dd>OSC 消息参数数组</dd>
+        <dt>topic <span class="property-type">string</span></dt>
+        <dd>OSC 地址</dd>
+        <dt>_ip <span class="property-type">string</span></dt>
+        <dd>发送方 IP 地址</dd>
+        <dt>_port <span class="property-type">number</span></dt>
+        <dd>发送方端口</dd>
+        <dt>_raw <span class="property-type">buffer</span></dt>
+        <dd>原始 OSC 二进制数据</dd>
+    </dl>
+    <h3>Details</h3>
+    <p>监听指定端口的 OSC 消息。支持 OSC Bundle 和单条消息。</p>
+    <p>支持通配符地址过滤：</p>
+    <ul>
+        <li><code>/ventuz/*</code> - 匹配所有 /ventuz/ 开头的地址</li>
+        <li><code>*</code> - 匹配所有地址</li>
+        <li><code>/ventuz/broadcast</code> - 精确匹配</li>
+    </ul>
+    <p>自动解码 BEUC 编码的中文字符串。</p>
+    <h3>Examples</h3>
+    <pre>// 接收到的消息格式
+{
+    "topic": "/ventuz/broadcast",
+    "payload": ["Hello", 123, 45.67],
+    "ip": "192.168.1.100",
+    "port": 12345
+}
+</pre>
+</script>

--- a/io/ventuz-osc/nodes/osc-in.js
+++ b/io/ventuz-osc/nodes/osc-in.js
@@ -1,0 +1,220 @@
+/**
+ * OSC In Node
+ * 接收 OSC 消息
+ */
+
+module.exports = function(RED) {
+    function OscInNode(config) {
+        RED.nodes.createNode(this, config);
+        var node = this;
+        
+        // 配置
+        node.port = parseInt(config.port) || 9001;
+        node.address = config.address || '/ventuz/*';
+        node.multicast = (config.multicast || '').trim();
+        node.iface = (config.iface || '').trim();
+        
+        // 状态
+        node.listening = false;
+        
+        // 初始化 UDP socket
+        var dgram = require('dgram');
+        node.socket = dgram.createSocket({ type: 'udp4', reuseAddr: true });
+        
+        // OSC 解码函数
+        function decodeOscString(buffer, offset) {
+            var end = offset;
+            while (end < buffer.length && buffer[end] !== 0) {
+                end++;
+            }
+            var str = buffer.toString('utf-8', offset, end);
+            var padding = (4 - (end - offset + 1) % 4) % 4;
+            return { value: str, nextOffset: end + 1 + padding };
+        }
+        
+        function decodeOscInt(buffer, offset) {
+            return { value: buffer.readInt32BE(offset), nextOffset: offset + 4 };
+        }
+        
+        function decodeOscFloat(buffer, offset) {
+            return { value: buffer.readFloatBE(offset), nextOffset: offset + 4 };
+        }
+        
+        function decodeOscBlob(buffer, offset) {
+            var len = buffer.readUInt32BE(offset);
+            var data = buffer.slice(offset + 4, offset + 4 + len);
+            var padding = (4 - len % 4) % 4;
+            
+            // 检查是否是 BEUC 编码（中文）
+            if (data.length >= 4 && data.slice(0, 4).toString('utf-8') === 'BEUC') {
+                var unicodeBytes = data.slice(4);
+                // 手动解码 UTF-16BE
+                var str = '';
+                for (var k = 0; k < unicodeBytes.length; k += 2) {
+                    str += String.fromCharCode(unicodeBytes.readUInt16BE(k));
+                }
+                return { value: str, nextOffset: offset + 4 + len + padding };
+            }
+            
+            return { value: data, nextOffset: offset + 4 + len + padding };
+        }
+        
+        function decodeOscMessage(buffer) {
+            var offset = 0;
+            
+            // 解析地址
+            var addressResult = decodeOscString(buffer, offset);
+            var address = addressResult.value;
+            offset = addressResult.nextOffset;
+            
+            // 解析类型标签
+            var typeResult = decodeOscString(buffer, offset);
+            var typeTags = typeResult.value;
+            offset = typeResult.nextOffset;
+            
+            // 解析参数
+            var args = [];
+            for (var i = 1; i < typeTags.length; i++) {
+                var tag = typeTags[i];
+                var result;
+                
+                switch (tag) {
+                    case 'i':
+                        result = decodeOscInt(buffer, offset);
+                        args.push(result.value);
+                        offset = result.nextOffset;
+                        break;
+                    case 'f':
+                        result = decodeOscFloat(buffer, offset);
+                        args.push(result.value);
+                        offset = result.nextOffset;
+                        break;
+                    case 's':
+                        result = decodeOscString(buffer, offset);
+                        args.push(result.value);
+                        offset = result.nextOffset;
+                        break;
+                    case 'b':
+                        result = decodeOscBlob(buffer, offset);
+                        args.push(result.value);
+                        offset = result.nextOffset;
+                        break;
+                    default:
+                        // 未知类型，跳过
+                        break;
+                }
+            }
+            
+            return { address: address, args: args };
+        }
+        
+        function decodeOscBundle(buffer) {
+            // 检查 bundle 头
+            if (buffer.length < 16) return null;
+            var header = buffer.toString('utf-8', 0, 8);
+            if (header !== '#bundle\x00') return null;
+            
+            var offset = 16; // 跳过 header 和 timetag
+            var messages = [];
+            
+            while (offset < buffer.length) {
+                if (offset + 4 > buffer.length) break;
+                var msgLen = buffer.readUInt32BE(offset);
+                offset += 4;
+                
+                if (offset + msgLen > buffer.length) break;
+                var msgBuffer = buffer.slice(offset, offset + msgLen);
+                offset += msgLen;
+                
+                var msg = decodeOscMessage(msgBuffer);
+                if (msg) {
+                    messages.push(msg);
+                }
+            }
+            
+            return messages;
+        }
+        
+        // 绑定端口监听
+        node.socket.bind(node.port, function() {
+            node.listening = true;
+            node.log('Listening for OSC messages on port ' + node.port);
+            node.status({fill: "green", shape: "dot", text: "port " + node.port});
+            
+            // 启用广播接收
+            node.socket.setBroadcast(true);
+            
+            // 如果配置了组播地址，加入组播组
+            if (node.multicast && /^22[4-9]\.|^23[0-9]\./.test(node.multicast)) {
+                try {
+                    node.socket.addMembership(node.multicast, node.iface || undefined);
+                    node.log('Joined multicast group: ' + node.multicast + (node.iface ? ' on interface ' + node.iface : ''));
+                } catch (e) {
+                    node.error('Failed to join multicast group: ' + e.message);
+                }
+            }
+        });
+        
+        // 接收 OSC 消息
+        node.socket.on('message', function(msg, rinfo) {
+            try {
+                var messages = [];
+                
+                // 尝试作为 bundle 解码
+                if (msg.length >= 8 && msg.toString('utf-8', 0, 8) === '#bundle\x00') {
+                    messages = decodeOscBundle(msg) || [];
+                } else {
+                    // 单条消息
+                    var decoded = decodeOscMessage(msg);
+                    if (decoded) {
+                        messages = [decoded];
+                    }
+                }
+                
+                // 处理每条消息
+                for (var i = 0; i < messages.length; i++) {
+                    var oscMsg = messages[i];
+                    
+                    // 地址过滤
+                    var addressPattern = node.address;
+                    if (addressPattern !== '*' && addressPattern !== '/ventuz/*') {
+                        var regexStr = '^' + addressPattern.replace(/\*/g, '.*').replace(/\//g, '\\/') + '$';
+                        var regex = new RegExp(regexStr);
+                        if (!regex.test(oscMsg.address)) {
+                            continue; // 不匹配则忽略
+                        }
+                    }
+                    
+                    // 输出消息
+                    node.send({
+                        topic: oscMsg.address,
+                        payload: oscMsg.args,
+                        _ip: rinfo.address,
+                        _port: rinfo.port,
+                        _raw: msg
+                    });
+                }
+                
+            } catch (e) {
+                node.error('OSC decoding error: ' + e.message);
+            }
+        });
+        
+        // 错误处理
+        node.socket.on('error', function(err) {
+            node.error('Socket error: ' + err.message);
+            node.listening = false;
+            node.status({fill: "red", shape: "ring", text: "error"});
+        });
+        
+        // 节点关闭时清理
+        node.on('close', function() {
+            if (node.socket) {
+                node.socket.close();
+            }
+            node.listening = false;
+        });
+    }
+    
+    RED.nodes.registerType("osc-in", OscInNode);
+};

--- a/io/ventuz-osc/nodes/osc-out.html
+++ b/io/ventuz-osc/nodes/osc-out.html
@@ -1,0 +1,74 @@
+<script type="text/javascript">
+    RED.nodes.registerType('osc-out', {
+        category: 'network',
+        color: '#a6bbcf',
+        defaults: {
+            name: { value: "" },
+            host: { value: "127.0.0.1", required: true },
+            port: { value: 9000, required: true, validator: RED.validators.number() },
+            address: { value: "/ventuz/broadcast", required: true },
+            iface: { value: "" }
+        },
+        inputs: 1,
+        outputs: 1,
+        icon: "bridge.svg",
+        label: function() {
+            return this.name || this.host + ':' + this.port;
+        },
+        paletteLabel: "osc out"
+    });
+</script>
+
+<script type="text/html" data-template-name="osc-out">
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+    <div class="form-row">
+        <label for="node-input-host"><i class="fa fa-globe"></i> Host</label>
+        <input type="text" id="node-input-host" placeholder="127.0.0.1">
+    </div>
+    <div class="form-row">
+        <label for="node-input-port"><i class="fa fa-plug"></i> Port</label>
+        <input type="text" id="node-input-port" placeholder="9000">
+    </div>
+    <div class="form-row">
+        <label for="node-input-address"><i class="fa fa-map-marker"></i> OSC Address</label>
+        <input type="text" id="node-input-address" placeholder="/ventuz/broadcast">
+    </div>
+    <div class="form-row">
+        <label for="node-input-iface"><i class="fa fa-server"></i> Interface IP</label>
+        <input type="text" id="node-input-iface" placeholder="0.0.0.0 (可选)">
+    </div>
+</script>
+
+<script type="text/html" data-help-name="osc-out">
+    <p>OSC Out 节点 - 发送 OSC 消息</p>
+    <h3>Inputs</h3>
+    <dl class="message-properties">
+        <dt>payload <span class="property-type">string | number | boolean | array | object</span></dt>
+        <dd>OSC 消息参数</dd>
+        <dt>topic <span class="property-type">string</span></dt>
+        <dd>OSC 地址（可选，覆盖节点配置）</dd>
+    </dl>
+    <h3>Details</h3>
+    <p>向指定目标发送 OSC 消息。支持以下数据类型：</p>
+    <ul>
+        <li><b>整数</b> - 32位有符号整数</li>
+        <li><b>浮点数</b> - 32位浮点数</li>
+        <li><b>字符串</b> - UTF-8 编码，支持中文（自动 BEUC 编码）</li>
+        <li><b>布尔值</b> - 自动转换为整数 (0/1)</li>
+        <li><b>Blob</b> - Buffer 类型数据</li>
+    </ul>
+    <p>消息格式为 OSC Bundle，包含时间戳。</p>
+    <h3>Examples</h3>
+    <pre>// 发送字符串
+[{"topic": "/ventuz/text", "payload": "Hello World"}]
+
+// 发送数字
+[{"topic": "/ventuz/value", "payload": 123.45}]
+
+// 发送数组（多个参数）
+[{"topic": "/ventuz/data", "payload": [1, 2.5, "test"]}]
+</pre>
+</script>

--- a/io/ventuz-osc/nodes/osc-out.js
+++ b/io/ventuz-osc/nodes/osc-out.js
@@ -1,0 +1,213 @@
+/**
+ * OSC Out Node
+ * 发送 OSC 消息到 Ventuz
+ * 基于 Python OSC 编码实现，支持中文 BEUC 编码
+ */
+
+module.exports = function(RED) {
+    function OscOutNode(config) {
+        RED.nodes.createNode(this, config);
+        var node = this;
+        
+        // 配置
+        node.host = (config.host || '127.0.0.1').trim();
+        node.port = parseInt(config.port) || 9000;
+        node.address = config.address || '/ventuz/broadcast';
+        node.iface = (config.iface || '').trim();
+        
+        // 状态
+        node.connected = false;
+        
+        // 初始化 UDP socket
+        var dgram = require('dgram');
+        node.socket = dgram.createSocket({ type: 'udp4', reuseAddr: true });
+        
+        // 检测是否为组播/广播地址
+        var isMulticast = /^22[4-9]\.|^23[0-9]\./.test(node.host);
+        var isBroadcast = node.host.endsWith('.255') || node.host === '255.255.255.255';
+        
+        // 绑定 socket 后再设置广播（发送端不需要加入组播组）
+        node.socket.bind(0, function() {
+            try {
+                if (isBroadcast) {
+                    // 广播地址：启用广播
+                    node.socket.setBroadcast(true);
+                    node.log('Broadcast enabled');
+                } else if (isMulticast) {
+                    // 组播配置
+                    node.socket.setMulticastLoopback(true);
+                    node.socket.setMulticastTTL(128);
+                    if (node.iface) {
+                        node.socket.setMulticastInterface(node.iface);
+                    }
+                    node.log('Multicast mode: sending to ' + node.host + (node.iface ? ' via ' + node.iface : ''));
+                }
+            } catch (e) {
+                node.error('Socket configuration error: ' + e.message);
+            }
+        });
+        
+        // OSC 编码函数
+        function isContainsChinese(s) {
+            for (var i = 0; i < s.length; i++) {
+                if (s.charCodeAt(i) > 127) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        
+        function encodeOscString(s) {
+            var encoded = Buffer.from(s, 'utf-8');
+            var withNull = Buffer.concat([encoded, Buffer.from([0x00])]);
+            var padding = (4 - withNull.length % 4) % 4;
+            return Buffer.concat([withNull, Buffer.alloc(padding, 0x00)]);
+        }
+        
+        function encodeOscInt(value) {
+            var buf = Buffer.alloc(4);
+            buf.writeInt32BE(value);
+            return buf;
+        }
+        
+        function encodeOscFloat(value) {
+            var buf = Buffer.alloc(4);
+            buf.writeFloatBE(value);
+            return buf;
+        }
+        
+        function padTo4(data) {
+            var padding = (4 - data.length % 4) % 4;
+            return Buffer.concat([data, Buffer.alloc(padding, 0x00)]);
+        }
+        
+        function encodeOscBundle() {
+            var elements = [];
+            for (var i = 0; i < arguments.length; i++) {
+                elements.push(arguments[i]);
+            }
+            
+            var bundleHeader = Buffer.from('#bundle\x00', 'utf-8');
+            var timetag = Buffer.alloc(8);
+            timetag.writeUInt32BE(0, 0);
+            timetag.writeUInt32BE(1, 4);
+            
+            var msg = Buffer.concat([bundleHeader, timetag]);
+            
+            for (var j = 0; j < elements.length; j++) {
+                var elem = elements[j];
+                var lenBuf = Buffer.alloc(4);
+                lenBuf.writeUInt32BE(elem.length);
+                msg = Buffer.concat([msg, lenBuf, elem]);
+            }
+            
+            return msg;
+        }
+        
+        function encodeOscElement(address, args) {
+            var addressBytes = encodeOscString(address);
+            var typeTags = ',';
+            var data = Buffer.alloc(0);
+            
+            for (var i = 0; i < args.length; i++) {
+                var arg = args[i];
+                
+                if (typeof arg === 'boolean') {
+                    typeTags += 'i';
+                    data = Buffer.concat([data, encodeOscInt(arg ? 1 : 0)]);
+                } else if (typeof arg === 'number') {
+                    if (Number.isInteger(arg)) {
+                        typeTags += 'i';
+                        data = Buffer.concat([data, encodeOscInt(arg)]);
+                    } else {
+                        typeTags += 'f';
+                        data = Buffer.concat([data, encodeOscFloat(arg)]);
+                    }
+                } else if (typeof arg === 'string') {
+                    if (isContainsChinese(arg)) {
+                        typeTags += 'b';
+                        // 手动编码 UTF-16BE
+                        var utf16beBytes = Buffer.alloc(arg.length * 2);
+                        for (var k = 0; k < arg.length; k++) {
+                            utf16beBytes.writeUInt16BE(arg.charCodeAt(k), k * 2);
+                        }
+                        var beucData = Buffer.concat([Buffer.from('BEUC', 'utf-8'), utf16beBytes]);
+                        var beucLen = Buffer.alloc(4);
+                        beucLen.writeUInt32BE(beucData.length);
+                        data = Buffer.concat([data, beucLen, padTo4(beucData)]);
+                    } else {
+                        typeTags += 's';
+                        data = Buffer.concat([data, encodeOscString(arg)]);
+                    }
+                } else {
+                    var argStr = String(arg);
+                    typeTags += 's';
+                    data = Buffer.concat([data, encodeOscString(argStr)]);
+                }
+            }
+            
+            var typeTagBytes = encodeOscString(typeTags);
+            return Buffer.concat([addressBytes, typeTagBytes, data]);
+        }
+        
+        function sendOsc(address, args) {
+            var element = encodeOscElement(address, args);
+            var bundle = encodeOscBundle(element);
+            
+            try {
+                node.socket.send(bundle, 0, bundle.length, node.port, node.host, function(err) {
+                    if (err) {
+                        node.error('Failed to send OSC message: ' + err.message);
+                    } else {
+                        node.log('Sent OSC: ' + address + ' -> ' + node.host + ':' + node.port);
+                    }
+                });
+            } catch (e) {
+                node.error('OSC send error: ' + e.message);
+            }
+        }
+        
+        // 处理输入消息
+        node.on('input', function(msg) {
+            if (!node.connected) {
+                node.warn('Socket not ready');
+                return;
+            }
+            
+            var address = msg.topic || node.address;
+            var payload = msg.payload;
+            var args = [];
+            
+            // 解析 payload 为 OSC 参数
+            if (Array.isArray(payload)) {
+                args = payload;
+            } else if (payload !== null && payload !== undefined) {
+                args = [payload];
+            }
+            
+            // 发送 OSC 消息
+            sendOsc(address, args);
+        });
+        
+        // 节点状态更新
+        node.socket.on('error', function(err) {
+            node.error('Socket error: ' + err.message);
+            node.connected = false;
+            node.status({fill: "red", shape: "ring", text: "error"});
+        });
+        
+        // 标记为已连接
+        node.connected = true;
+        node.status({fill: "green", shape: "dot", text: node.host + ':' + node.port});
+        
+        // 节点关闭时清理
+        node.on('close', function() {
+            if (node.socket) {
+                node.socket.close();
+            }
+            node.connected = false;
+        });
+    }
+    
+    RED.nodes.registerType("osc-out", OscOutNode);
+};

--- a/io/ventuz-osc/package.json
+++ b/io/ventuz-osc/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "node-red-contrib-ventuz-osc",
+  "version": "0.0.8",
+  "description": "Node-RED nodes for Ventuz OSC communication",
+  "keywords": [
+    "node-red",
+    "ventuz",
+    "osc",
+    "realtime",
+    "broadcast"
+  ],
+  "license": "MIT",
+  "author": "c3812600 <c3812600@qq.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/c3812600/node-red-contrib-ventuz-osc.git"
+  },
+  "bugs": {
+    "url": "https://github.com/c3812600/node-red-contrib-ventuz-osc/issues"
+  },
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "node-red": {
+    "version": ">=2.0.0",
+    "nodes": {
+      "osc-out": "nodes/osc-out.js",
+      "osc-in": "nodes/osc-in.js"
+    }
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=14.0.0"
+  }
+}


### PR DESCRIPTION
## Add Ventuz OSC communication nodes for Node-RED

This PR adds the 
ode-red-contrib-ventuz-osc package to the official Node-RED nodes collection.

### Nodes included:
- **osc-out**: Send OSC messages to Ventuz (with Chinese BEUC encoding support)
- **osc-in**: Receive Ventuz broadcast OSC messages

### Features:
- Complete OSC Bundle support
- Chinese string auto BEUC encoding
- int, float, string, blob data types
- Wildcard address filtering
- Track sender IP/port

### Package info:
- npm: https://www.npmjs.com/package/node-red-contrib-ventuz-osc
- GitHub: https://github.com/c3812600/node-red-contrib-ventuz-osc

### Checklist:
- [x] I have read the contribution guidelines
- [x] Package is already published to npm
- [x] Package follows naming convention (node-red-contrib-*)
- [x] README with installation and usage instructions
- [x] MIT License